### PR TITLE
Make submodules point to https URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/imgui"]
 	path = external/imgui
-	url = git@github.com:datoviz/imgui.git
+	url = https://github.com/datoviz/imgui
 [submodule "external/cglm"]
 	path = external/cglm
-	url = git@github.com:recp/cglm.git
+	url = https://github.com/recp/cglm
 [submodule "data"]
 	path = data
-	url = git@github.com:datoviz/data.git
+	url = https://github.com/datoviz/datoviz

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/recp/cglm
 [submodule "data"]
 	path = data
-	url = https://github.com/datoviz/datoviz
+	url = https://github.com/datoviz/data


### PR DESCRIPTION
Since the submodule URLs are of the form `git@github.com:datoviz/repo.git`, the repository can only be recursively cloned by users that have SSH keys authenticated with GitHub.