### PR TITLE
Add GitHub workflow for wheel and sdist building and upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,87 @@
+name: cibuildwheel
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
+    - name: Use MSBuild (Windows)
+      uses: microsoft/setup-msbuild@v1.0.2
+      if: matrix.os == 'windows-2019'
+    - uses: actions/setup-python@v2
+      name: Install Python
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install --upgrade pip
+        pip install cibuildwheel
+    - name: Build wheels
+      run: python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* pp* *-win32"
+        CIBW_TEST_REQUIRES: "pytest pytest-sugar meshio pillow"
+        CIBW_TEST_COMMAND: "python -c \"import vispy; vispy.test()\""
+        CIBW_BUILD_VERBOSITY: "2"
+        CIBW_BEFORE_BUILD: "pip install -U numpy Cython; source ~/vulkan/setup-env.sh"
+        CIBW_BEFORE_BUILD_MACOS: "pip install -U pip setuptools"
+        CIBW_BEFORE_BUILD_LINUX: "yum install -y gcc gcc-c++ make cmake ninja-build xcb libX11-devel libX11-xcb fontconfig glfw3-devel patchelf; pip install -U pip setuptools; pip install freetype-py; source ~/vulkan/setup-env.sh"
+        # If freetype-py is installed from source (no wheel found), include bundled freetype library
+        CIBW_ENVIRONMENT_WINDOWS: "FREETYPEPY_BUNDLE_FT=1"
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.7'
+    # TODO: Install apt packages (should we use CentOS to be consistent with cibuildwheel)?
+    - name: Build sdist
+      run: |
+        source ~/vulkan/setup-env.sh
+        python -m pip install --upgrade pip
+        pip install numpy Cython
+        ./manage.sh build
+        ./manage.sh cython
+        source setup-env.sh
+        python setup.py sdist
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.DATOVIZ_PYPI_TOKEN }}
+        # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Based on discussion in #22 

This is a basically an almost straight copy/paste from vispy's github workflow which we've only used once or twice. I decided to use vispy's workflow instead of some of my other projects that have fancier workflows because vispy is closer to datoviz's build process with freetype and other stuff. We'll see how this goes.

There are a lot of steps I see in the install from source documentation and I'm not sure how many of them transfer to this 1:1. Also, this has the "cibuildwheel" tool to create all the wheels which means some of the build commands have to go into environment variables. It might be easier to put these into scripts (ex. `<repos root>/ci/`). I'm going to focus on linux first and see if we can get that working.

This won't show up in datoviz's Actions until merged so if you want to see the current status you can go here: https://github.com/djhoese/datoviz/actions