### PR TITLE
Install all the headers and allow library installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(FetchContent)
 
 set(CMAKE_C_STANDARD)
 set(CMAKE_C_STANDARD_REQUIRED True)
+include(GNUInstallDirs)
 
 
 # Options
@@ -449,13 +450,17 @@ file(GLOB imgui_sources
     "external/imgui/backends/imgui_impl_vulkan.*"
 )
 
+file(GLOB DATOVIZ_HEADERS
+    "include/datoviz/*.h"
+)
+
 set_source_files_properties(${imgui_sources} PROPERTIES COMPILE_FLAGS -w)
 add_library(datoviz SHARED ${sources} ${path_shadersc} ${path_colortex} ${path_fonts})
 
 set_target_properties(datoviz PROPERTIES
     VERSION ${DATOVIZ_VERSION}
     SOVERSION 1
-    PUBLIC_HEADER include/datoviz/datoviz.h)
+    PUBLIC_HEADER "${DATOVIZ_HEADERS}")
 add_dependencies(datoviz shaders)
 
 target_compile_definitions(datoviz PUBLIC ${COMPILE_DEFINITIONS})
@@ -507,6 +512,14 @@ if (DATOVIZ_WITH_CLI)
     add_test(NAME datoviz_test COMMAND datovizcli test)
 endif()
 
+install(
+    TARGETS datoviz
+    EXPORT  datoviz
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/datoviz
+)
 
 # -------------------------------------------------------------------------------------------------
 # Leftovers


### PR DESCRIPTION
Closes https://github.com/datoviz/datoviz/issues/53

This allows users to install the library enabling higher level languages to share the c library.