### PR TITLE
Let native python interactive use the native loop

### DIFF
--- a/bindings/cython/datoviz/__init__.py
+++ b/bindings/cython/datoviz/__init__.py
@@ -185,7 +185,7 @@ def run_native(n_frames=0, **kwargs):
 
 def run(n_frames=0, event_loop=None, **kwargs):
     event_loop = event_loop or 'native'
-    if event_loop == 'ipython' or is_interactive():
+    if event_loop == 'ipython':
         enable_ipython()
     elif event_loop == 'native':
         run_native(n_frames, **kwargs)


### PR DESCRIPTION
I think that this line is stopping me from using the bare python interpreter.

hard to say which is the right interaction, but this currently would fail on an import error due to missing ipython