### PR TITLE
Justfile changes to ensure Windows build works.

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,6 +164,10 @@ checkstructs:
     import ctypes
     import json
 
+    # Insure local datoviz module is imported.
+    import sys
+    sys.path.insert(0, '.')
+
     def _check_struct_sizes(json_path):
         """Check the size of the ctypes structs and unions with respect to the sizes output by
         the CMake process (small executable in tools/struct_sizes.c compiled and executed by CMake).
@@ -330,6 +334,14 @@ build release="Debug":
     pushd build/
     CMAKE_CXX_COMPILER_LAUNCHER=ccache cmake .. --preset=default -DCMAKE_BUILD_TYPE={{release}}
     cmake --build .
+
+    # Copy vcpkg_installed dll's to datoviz.exe location.
+    if [ "{{release}}" == "Debug" ]; then
+        cp vcpkg_installed/x64-windows/debug/bin/*.dll .
+    else
+        cp vcpkg_installed/x64-windows/bin/*.dll .
+    fi
+
     popd
 #
 

--- a/tools/struct_sizes.c
+++ b/tools/struct_sizes.c
@@ -23,9 +23,9 @@ int main(void)
     printf("  \"DvzWindowEvent\": %u,\n", (unsigned)sizeof(DvzWindowEvent));
     printf("  \"DvzFrameEvent\": %u,\n", (unsigned)sizeof(DvzFrameEvent));
     printf("  \"DvzTimerEvent\": %u,\n", (unsigned)sizeof(DvzTimerEvent));
-    printf("  \"DvzRequestsEvent\": %,u\n", (unsigned)sizeof(DvzRequestsEvent));
-    printf("  \"DvzRecorderCommand\": %,u\n", (unsigned)sizeof(DvzRecorderCommand));
-    printf("  \"DvzRequestContent\": %,u\n", (unsigned)sizeof(DvzRequestContent));
+    printf("  \"DvzRequestsEvent\": %u,\n", (unsigned)sizeof(DvzRequestsEvent));
+    printf("  \"DvzRecorderCommand\": %u,\n", (unsigned)sizeof(DvzRecorderCommand));
+    printf("  \"DvzRequestContent\": %u,\n", (unsigned)sizeof(DvzRequestContent));
     printf("  \"DvzRequest\": %u\n", (unsigned)sizeof(DvzRequest));
     printf("}\n");
     return 0;

--- a/tools/struct_sizes.c
+++ b/tools/struct_sizes.c
@@ -23,9 +23,9 @@ int main(void)
     printf("  \"DvzWindowEvent\": %u,\n", (unsigned)sizeof(DvzWindowEvent));
     printf("  \"DvzFrameEvent\": %u,\n", (unsigned)sizeof(DvzFrameEvent));
     printf("  \"DvzTimerEvent\": %u,\n", (unsigned)sizeof(DvzTimerEvent));
-    printf("  \"DvzRequestsEvent\": %u\n", (unsigned)sizeof(DvzRequestsEvent));
-    printf("  \"DvzRecorderCommand\": %u\n", (unsigned)sizeof(DvzRecorderCommand));
-    printf("  \"DvzRequestContent\": %u\n", (unsigned)sizeof(DvzRequestContent));
+    printf("  \"DvzRequestsEvent\": %,u\n", (unsigned)sizeof(DvzRequestsEvent));
+    printf("  \"DvzRecorderCommand\": %,u\n", (unsigned)sizeof(DvzRecorderCommand));
+    printf("  \"DvzRequestContent\": %,u\n", (unsigned)sizeof(DvzRequestContent));
     printf("  \"DvzRequest\": %u\n", (unsigned)sizeof(DvzRequest));
     printf("}\n");
     return 0;


### PR DESCRIPTION
* Copy vcpkg_installed debug or release dlls to location of datoviz.exe.

Building on windows does not copy the dlls from sub directories of vcpkg_installed.  If those files are in the path elsewhere, a build will succeed, but possibly not with the intended versions.  If they are not present, then an error indicating the dll or one of the dependents can't be found.

* Insure local datoviz module is imported instead of previously installed package.

This fixes the case where a failure occurs where previously installed package is imported instead of the local just created module, or a failure due to the local module not being in the path.