### PR TITLE
Fixes for sphere visual.

### DIFF
--- a/examples/visuals/sphere.py
+++ b/examples/visuals/sphere.py
@@ -21,8 +21,7 @@ def generate_ndc_grid(n):
     z_norm = (z + 1) / 2
 
     # Radius increases linearly in all directions (can be tuned)
-    radius = 10 + 5 * np.exp(1 * (x_norm + y_norm + z_norm))
-    # radius = radius.max() + radius.min() - radius
+    radius = 10 + 4 * np.exp(1 * (x_norm + y_norm + z_norm))
     radius = radius.flatten()
 
     r = x_norm.flatten()
@@ -37,22 +36,20 @@ def generate_ndc_grid(n):
 
 N, position, color, size = generate_ndc_grid(8)
 
+width, height = 800, 600
 app = dvz.App()
 figure = app.figure()
-panel = figure.panel()
+panel = figure.panel(offset=(0,0), size=(width, height))
 arcball = panel.arcball()
 
 visual = app.sphere(
     position=position,
     color=color,
-    size=size,
+    size=size/height,            # Pixels to normalized screen size.
     light_pos=(-5, +5, +100),
-    light_params=(0.4, 0.8, 2, 32),
+    light_params=(0.4, 0.8, 1, 32),
 )
 panel.add(visual)
-
-# dvz.arcball_initial(arcball, vec3(.6, .1, 1.5))
-# dvz.panel_update(panel)
 
 app.run()
 app.destroy()

--- a/src/scene/glsl/graphics_sphere.vert
+++ b/src/scene/glsl/graphics_sphere.vert
@@ -16,26 +16,25 @@ params;
 
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec4 color;
-layout(location = 2) in float radius;
+layout(location = 2) in float size;
 
 layout(location = 0) out vec4 out_color;
 layout(location = 1) out vec4 out_pos;
 layout(location = 2) out float out_radius;
-layout(location = 3) out vec4 out_eye_pos;
+layout(location = 3) out vec4 out_cam_pos;
 
 void main()
 {
-    out_radius = radius;
+    out_radius = size / 2.0;       // Needs to be reltive to screen in fragment shader.
     out_color = color;
 
     // Calculate position and eye-space position
     out_pos = mvp.model * vec4(pos, 1.0);
-    out_eye_pos = mvp.view * out_pos;
+    out_cam_pos = inverse(mvp.view) * vec4(0, 0, 0, 1);
 
     // Project the position to clip space using the transform function
     gl_Position = transform(pos);
 
-    // Set the point size to the diameter of the sphere in pixels
-    float distance_to_camera = length(out_eye_pos.xyz);
-    gl_PointSize = (2.0 * radius) / distance_to_camera;
+    // Set the point size to the diameter of the sphere and scale to window.
+    gl_PointSize = size * viewport.size.y * mvp.proj[1][1] / gl_Position.w;
 }


### PR DESCRIPTION
Scaling works with spheres as the arcball is zoomed in.

Works with other cameras too.

Some improvements to render code to avoid clipped colors.

Change to API:
   Sphere size is in percentage of screen height.

   If size data is specified in pixels, then divide by screen height when initiating the visual.