### PR TITLE
Fix texture data upload

### DIFF
--- a/datoviz/_texture.py
+++ b/datoviz/_texture.py
@@ -84,4 +84,4 @@ class Texture:
         elif self.ndim == 3:
             h, w, d = image.shape[:3]
 
-        dvz.texture_data(self.c_texture, x, y, z, w, h, d, image.size, image)
+        dvz.texture_data(self.c_texture, x, y, z, w, h, d, image.nbytes, image)


### PR DESCRIPTION
Texture data (upload) function assumed texture to be uint8 and so size for float32 textures was incorrect.

Change to use 'image.nbytes' fixes cases where the array data type is float32. 
