### PR TITLE
bugfix: shape_transform requires column major transform

### DIFF
--- a/datoviz/shape_collection.py
+++ b/datoviz/shape_collection.py
@@ -75,7 +75,7 @@ def _shape_transform(
     # dvz.shape_rotate(c_shape, angle, axis)
     if transform is not None:
         dvz.shape_transform(
-            c_shape, dvz.mat4(*map(float, np.array(transform, dtype=np.float32).flatten()))
+            c_shape, dvz.mat4(*map(float, np.array(transform, dtype=np.float32).flatten(order='F')))
         )
 
     dvz.shape_end(c_shape)


### PR DESCRIPTION
`cglm` requires column major ordering: https://cglm.readthedocs.io/en/latest/index.html

The flatten function does row major ordering by default: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flatten.html

If you run this script:
```python
import datoviz as dvz
import numpy as np
from scipy.spatial.transform import Rotation

a1 = np.array([0.1, 0.2, 0.3])
a2 = np.array([0.3, 0.2, 0.1])

T1 = np.eye(4)
T1[:3, :3] = Rotation.random().as_matrix()
T1[:3, 3] = np.array([1.0, 0.0, 0.0])

T2 = np.eye(4)
T2[:3, :3] = Rotation.random().as_matrix()
T2[:3, 3] = np.array([0.0, -1.0, 0.0])

# visualize
app = dvz.App()
figure = app.figure()
panel = figure.panel()
panel.arcball()

sc = dvz.ShapeCollection()
sc.add_sphere(scale=(a1[0], a1[1], a1[2]), transform=T1, color=(255, 0, 0, 255))
sc.add_sphere(scale=(a2[0], a2[1], a2[2]), transform=T2, color=(0, 255, 0, 255))
visual = app.mesh(sc, lighting=True, depth_test=True)

panel.add(visual)
app.run()
app.destroy()
```
then, without correcting `flatten` you get
<img width="912" alt="Screenshot 2025-07-09 at 00 20 48" src="https://github.com/user-attachments/assets/f9d82ccc-5a40-4694-94be-9c1aede203f2" />
which is incorrect as there should be a non-trivial translation between the ellipsoids. Now with the corrected `flatten` we get
<img width="912" alt="Screenshot 2025-07-09 at 00 21 07" src="https://github.com/user-attachments/assets/19ac40d0-5689-4239-91f1-f4737ad078c5" />
