### PR TITLE
Toggle colorbar visibility and adjust colorbar panel shape

### DIFF
--- a/datoviz/_ctypes.py
+++ b/datoviz/_ctypes.py
@@ -8463,6 +8463,24 @@ colorbar_update.argtypes = [
 
 
 # -------------------------------------------------------------------------------------------------
+colorbar_show = dvz.dvz_colorbar_show
+colorbar_show.__doc__ = """
+Set the visibility of a colorbar.
+
+Parameters
+----------
+colorbar : DvzColorbar*
+    the colorbar
+is_visible : bool
+    the colorbar visibility
+"""
+colorbar_show.argtypes = [
+    ctypes.POINTER(DvzColorbar),  # DvzColorbar* colorbar
+    ctypes.c_bool,  # bool is_visible
+]
+
+
+# -------------------------------------------------------------------------------------------------
 colorbar_destroy = dvz.dvz_colorbar_destroy
 colorbar_destroy.__doc__ = """
 Destroy a colorbar.

--- a/datoviz/_figure.py
+++ b/datoviz/_figure.py
@@ -207,9 +207,18 @@ class Figure:
         """
         return dvz.figure_id(self.c_figure)
 
-    def _create_colorbar_panel(self):
+    def _create_colorbar_panel(self, cw: int = 80, ch_offset: int = 40, m: int = 20):
         """
         Create and return a panel for the colorbar.
+
+        Parameters
+        ----------
+        cw : int
+            Colorbar width.
+        ch_offset : int
+            Colorbar height offset.
+        m : int
+            Colorbar margin.
 
         Returns
         -------
@@ -217,13 +226,19 @@ class Figure:
             The panel used for displaying the colorbar.
         """
         w, h = self.size()
-        cw, ch = 80, h - 40
-        m = 20
-        colorbar_panel = self.panel((w - cw - m, m), (cw, ch))
+        colorbar_panel = self.panel((w - cw - m, m), (cw, h - ch_offset))
         colorbar_panel.margins(m // 2, m // 2, m // 2, m // 2)
         return colorbar_panel
 
-    def colorbar(self, cmap: str = 'hsv', dmin: float = 0, dmax: float = 1):
+    def colorbar(
+        self,
+        cmap: str = 'hsv',
+        dmin: float = 0,
+        dmax: float = 1,
+        cw: int = 80,
+        ch_offset: int = 40,
+        m: int = 20,
+    ):
         """
         Create a colorbar in the figure.
 
@@ -235,6 +250,12 @@ class Figure:
             Minimum data value.
         dmax : float
             Maximum data value.
+        cw : int
+            Colorbar width.
+        ch_offset : int
+            Colorbar height offset.
+        m : int
+            Colorbar margin.
 
         Returns
         -------
@@ -244,7 +265,7 @@ class Figure:
         c_cmap = to_enum(f'cmap_{cmap}')
         c_colorbar = dvz.colorbar(self._app.c_batch, c_cmap, dmin, dmax, 0)
 
-        colorbar_panel = self._create_colorbar_panel()
+        colorbar_panel = self._create_colorbar_panel(cw, ch_offset, m)
         dvz.colorbar_panel(c_colorbar, colorbar_panel.c_panel)
         return Colorbar(c_colorbar, colorbar_panel)
 

--- a/datoviz/_figure.py
+++ b/datoviz/_figure.py
@@ -80,6 +80,17 @@ class Colorbar:
         """
         dvz.colorbar_range(self.c_colorbar, dmin, dmax)
 
+    def show(self, is_visible: bool = True) -> None:
+        """
+        Show or hide the colorbar.
+
+        Parameters
+        ----------
+        is_visible : bool, optional
+            Whether to show the colorbar, by default True.
+        """
+        dvz.colorbar_show(self.c_colorbar, is_visible)
+
     def destroy(self):
         """
         Destroy the colorbar.

--- a/datoviz/shape_collection.py
+++ b/datoviz/shape_collection.py
@@ -75,7 +75,8 @@ def _shape_transform(
     # dvz.shape_rotate(c_shape, angle, axis)
     if transform is not None:
         dvz.shape_transform(
-            c_shape, dvz.mat4(*map(float, np.array(transform, dtype=np.float32).flatten(order='F')))
+            c_shape,
+            dvz.mat4(*map(float, np.array(transform, dtype=np.float32).flatten(order='F'))),
         )
 
     dvz.shape_end(c_shape)

--- a/datoviz/utils.py
+++ b/datoviz/utils.py
@@ -377,11 +377,12 @@ def to_enum(enumstr: Union[str, int], prefixes: Optional[List] = None) -> int:
     else:
         for prefix in prefixes:
             try:
-                return to_enum(f"{prefix}_{enumstr}")
+                return to_enum(f'{prefix}_{enumstr}')
             except ValueError as e:
                 pass
         raise ValueError(
-            f"Couldn't find enumeration {enumstr} with prefixes {', '.join(prefixes)}.")
+            f"Couldn't find enumeration {enumstr} with prefixes {', '.join(prefixes)}."
+        )
 
 
 # -------------------------------------------------------------------------------------------------

--- a/datoviz/visuals.py
+++ b/datoviz/visuals.py
@@ -1027,10 +1027,10 @@ class Path(Visual):
                 position = [position]
             elif isinstance(groups, int):
                 k = position.shape[0] // groups
-                position = [position[i * k: (i + 1) * k] for i in range(groups)]
+                position = [position[i * k : (i + 1) * k] for i in range(groups)]
             elif is_enumerable(groups):
                 indices = np.cumsum([0] + list(groups))
-                position = [position[indices[i]: indices[i + 1]] for i in range(len(groups))]
+                position = [position[indices[i] : indices[i + 1]] for i in range(len(groups))]
 
         # Ensure we get a list of positions in the end.
         assert isinstance(position, list)

--- a/examples/benchmarks/benchmark_mpl.py
+++ b/examples/benchmarks/benchmark_mpl.py
@@ -119,6 +119,7 @@ def zoom_matplotlib(ax, total_zoom: float):
 # Generate shared data
 # -------------------------------------------------------------------------------------------------
 
+
 def generate_data(n):
     rng = np.random.default_rng(3141)
     x, y = rng.random((2, n))

--- a/include/datoviz.h
+++ b/include/datoviz.h
@@ -3168,6 +3168,16 @@ DVZ_EXPORT void dvz_colorbar_update(DvzColorbar* colorbar);
 
 
 /**
+ * Set the visibility of a colorbar.
+ *
+ * @param colorbar the colorbar
+ * @param is_visible the colorbar visibility
+ */
+DVZ_EXPORT void dvz_colorbar_show(DvzColorbar* colorbar, bool is_visible);
+
+
+
+/**
  * Destroy a colorbar.
  *
  * @param colorbar the colorbar

--- a/pytests/non-automated/manual_test_fullscreen.py
+++ b/pytests/non-automated/manual_test_fullscreen.py
@@ -1,13 +1,14 @@
 """
-    manual_test_fullscreen.py
+manual_test_fullscreen.py
 
-    1: Start in window mode.
-        Switch to fullscreen, then back to window mode.
+1: Start in window mode.
+    Switch to fullscreen, then back to window mode.
 
-    2: Start in fullscreen mode.
-        Switch to window, then back to fullscreen mode.
+2: Start in fullscreen mode.
+    Switch to window, then back to fullscreen mode.
 
 """
+
 import time
 import numpy as np
 import datoviz as dvz
@@ -27,7 +28,6 @@ texcoords = np.array([[0, 0, 1, 1]], dtype=np.float32)
 
 
 def show_image(fullscreen: bool = False, resize: bool = False) -> None:
-
     app = dvz.App()
     figure = app.figure(fullscreen=fullscreen)
     panel = figure.panel(background=True)
@@ -51,19 +51,17 @@ def show_image(fullscreen: bool = False, resize: bool = False) -> None:
         case += 1
         if case < 3:
             fullscreen = not fullscreen
-            print(f"Case: {case}, fullscreen: {fullscreen}")
+            print(f'Case: {case}, fullscreen: {fullscreen}')
 
             figure.set_fullscreen(fullscreen)
         else:
             app.stop()
-
 
     app.run()
     app.destroy()
 
 
 def show_visual(fullscreen: bool = False, resize: bool = False) -> None:
-
     app = dvz.App()
     figure = app.figure(fullscreen=fullscreen)
 
@@ -80,12 +78,11 @@ def show_visual(fullscreen: bool = False, resize: bool = False) -> None:
         case += 1
         if case < 3:
             fullscreen = not fullscreen
-            print(f"Case: {case}, fullscreen: {fullscreen}")
+            print(f'Case: {case}, fullscreen: {fullscreen}')
 
             figure.set_fullscreen(fullscreen)
         else:
             app.stop()
-
 
     app.run()
     app.destroy()
@@ -93,8 +90,8 @@ def show_visual(fullscreen: bool = False, resize: bool = False) -> None:
     time.sleep(2)
     print()
 
-if __name__ == "__main__":
 
+if __name__ == '__main__':
     show_image(fullscreen=False)
     show_image(fullscreen=True)
 

--- a/src/scene/colorbar.c
+++ b/src/scene/colorbar.c
@@ -247,12 +247,11 @@ void dvz_colorbar_update(DvzColorbar* colorbar)
 void dvz_colorbar_show(DvzColorbar* colorbar, bool is_visible)
 {
     ANN(colorbar);
-    colorbar->image->is_visible = is_visible;
-    colorbar->axis->glyph->is_visible = is_visible;
-    colorbar->axis->segment->is_visible = is_visible;
-    colorbar->axis->factor->is_visible = is_visible;
-    colorbar->axis->label->is_visible = is_visible;
-    colorbar->axis->spine->is_visible = is_visible;
+    dvz_visual_show(colorbar->image, is_visible);
+    dvz_visual_show(colorbar->axis->glyph, is_visible);
+    dvz_visual_show(colorbar->axis->segment, is_visible);
+    dvz_visual_show(colorbar->axis->factor, is_visible);
+    dvz_visual_show(colorbar->axis->label, is_visible);
 }
 
 

--- a/src/scene/colorbar.c
+++ b/src/scene/colorbar.c
@@ -244,6 +244,19 @@ void dvz_colorbar_update(DvzColorbar* colorbar)
 
 
 
+void dvz_colorbar_show(DvzColorbar* colorbar, bool is_visible)
+{
+    ANN(colorbar);
+    colorbar->image->is_visible = is_visible;
+    colorbar->axis->glyph->is_visible = is_visible;
+    colorbar->axis->segment->is_visible = is_visible;
+    colorbar->axis->factor->is_visible = is_visible;
+    colorbar->axis->label->is_visible = is_visible;
+    colorbar->axis->spine->is_visible = is_visible;
+}
+
+
+
 void dvz_colorbar_destroy(DvzColorbar* colorbar)
 {
     ANN(colorbar);

--- a/symbols.map
+++ b/symbols.map
@@ -38,6 +38,7 @@ dvz_colorbar_destroy
 dvz_colorbar_panel
 dvz_colorbar_position
 dvz_colorbar_range
+dvz_colorbar_show
 dvz_colorbar_size
 dvz_colorbar_update
 dvz_colormap


### PR DESCRIPTION
- Toggle for colorbar visibility via `dvz_colorbar_show`
- Additional parameters to the `figure.colorbar` method that are used to adjust the colorbar panel width, height offset, and margin (previously hard-coded).