### PR TITLE
Deprecate texture assignment via property in Visual class

### DIFF
--- a/datoviz/visuals.py
+++ b/datoviz/visuals.py
@@ -186,9 +186,6 @@ class Visual:
                 value = to_enum(f'{enum_prefix}_{value}')
                 values = (value,)
 
-            elif prop_type == 'texture':
-                assert False, 'Setting texture via property is deprecated.'
-
             elif prop_type in dvz.VEC_TYPES:
                 assert hasattr(value, '__len__')
                 value = prop_type(*value)


### PR DESCRIPTION
- i ran 'just examples' and looked at the generated screenshot, all seems ok

# Changes
- removed deprecated code in Visual.__setattr__ to set texture
  - it has been deprecated since the Texture object has been introduced in the C api
- i left an assert 'just in case'