### PR TITLE
Fix dvz_msdf_from_svg and dvz_sdf_from_svg compilation issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,10 +361,8 @@ set(HAS_MSDF 0)
 if(DATOVIZ_WITH_MSDF)
     set(HAS_MSDF 1)
 
-    set(MSDFGEN_CORE_ONLY OFF)
-    set(MSDFGEN_BUILD_STANDALONE OFF)
-    set(MSDFGEN_USE_SKIA OFF)
-    set(MSDFGEN_DISABLE_SVG OFF)
+    # WARNING: msdfgen-atlas defaults MSDFGEN_DISABLE_SVG to ON, so we set this at project scope in advance
+    set(MSDFGEN_DISABLE_SVG OFF CACHE BOOL "Disable SVG functionality")
 
     set(MSDF_ATLAS_BUILD_STANDALONE OFF)
     set(MSDF_ATLAS_USE_VCPKG ${OS_WINDOWS})

--- a/src/scene/sdf.cpp
+++ b/src/scene/sdf.cpp
@@ -83,7 +83,7 @@ float* dvz_sdf_from_svg(const char* svg_path, uint32_t width, uint32_t height)
     uint32_t w = width;
     uint32_t h = height;
 
-#if (HAS_MSDF && !MSDFGEN_DISABLE_SVG)
+#if (HAS_MSDF && !defined(MSDFGEN_DISABLE_SVG))
     // Build the Shape.
     Shape shape;
     buildShapeFromSvgPath(shape, svg_path);
@@ -118,7 +118,7 @@ float* dvz_msdf_from_svg(const char* svg_path, uint32_t width, uint32_t height)
     uint32_t w = width;
     uint32_t h = height;
 
-#if (HAS_MSDF && !MSDFGEN_DISABLE_SVG)
+#if (HAS_MSDF && !defined(MSDFGEN_DISABLE_SVG))
     // Build the Shape.
     Shape shape;
     buildShapeFromSvgPath(shape, svg_path);

--- a/src/scene/sdf.cpp
+++ b/src/scene/sdf.cpp
@@ -83,7 +83,7 @@ float* dvz_sdf_from_svg(const char* svg_path, uint32_t width, uint32_t height)
     uint32_t w = width;
     uint32_t h = height;
 
-#if HAS_MSDF
+#if (HAS_MSDF && !MSDFGEN_DISABLE_SVG)
     // Build the Shape.
     Shape shape;
     buildShapeFromSvgPath(shape, svg_path);
@@ -118,7 +118,7 @@ float* dvz_msdf_from_svg(const char* svg_path, uint32_t width, uint32_t height)
     uint32_t w = width;
     uint32_t h = height;
 
-#if HAS_MSDF
+#if (HAS_MSDF && !MSDFGEN_DISABLE_SVG)
     // Build the Shape.
     Shape shape;
     buildShapeFromSvgPath(shape, svg_path);


### PR DESCRIPTION
Currently C/C++ build with default settings sets `MSDFGEN_DISABLE_SVG` to true.
Which can be verified via compilation flags in `compile_commands.json`: `-DMSDFGEN_DISABLE_SVG`.

Therefore we have two missing definitions:
```shell
./src/scene/sdf.cpp:89:5: error: use of undeclared identifier 'buildShapeFromSvgPath'
   89 |     buildShapeFromSvgPath(shape, svg_path);
      |     ^~~~~~~~~~~~~~~~~~~~~
./src/scene/sdf.cpp:124:5: error: use of undeclared identifier 'buildShapeFromSvgPath'
  124 |     buildShapeFromSvgPath(shape, svg_path);
      |     ^~~~~~~~~~~~~~~~~~~~~
```

Whether or not this default setting is intentional, most likely we should exclude those two references from the compilation, if we are building without the SVG support.

The fix modifies preprocessor directives - without the SVG support those functions now return NULL.