### PR TITLE
Improve Windows/macOS build support and library embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,14 @@ set(DVZ_GLFW_DIR "${PROJECT_SOURCE_DIR}/external/glfw")
 
 if(DVZ_WITH_GLFW)
     if(DVZ_VENDORED_DEPS)
-        if(EXISTS "${DVZ_GLFW_DIR}/CMakeLists.txt")
+        if(TARGET glfw)
+            # An embedding project may already have built GLFW; reuse its target instead of
+            # adding the vendored copy, which would fail on the duplicate `glfw` target.
+            set(DVZ_HAS_GLFW 1)
+            if(NOT TARGET glfw::glfw)
+                add_library(glfw::glfw ALIAS glfw)
+            endif()
+        elseif(EXISTS "${DVZ_GLFW_DIR}/CMakeLists.txt")
             set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
             set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
             set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,11 +1,127 @@
 {
-    "version": 2,
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
     "configurePresets": [
         {
-            "name": "mingw",
-            "displayName": "MinGW Makefiles",
-            "description": "Generate build files with MinGW Makefiles",
+            "name": "base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "dev-linux-debug",
+            "displayName": "Linux (GCC) - Debug",
+            "description": "Debug development build for Linux.",
+            "inherits": "base",
+            "generator": "Unix Makefiles",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-linux-release",
+            "displayName": "Linux (GCC) - Release",
+            "description": "Release development build for Linux.",
+            "inherits": "dev-linux-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "dev-macos-debug",
+            "displayName": "macOS (Clang) - Debug",
+            "description": "Debug development build for macOS.",
+            "inherits": "base",
+            "generator": "Unix Makefiles",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-macos-release",
+            "displayName": "macOS (Clang) - Release",
+            "description": "Release development build for macOS.",
+            "inherits": "dev-macos-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "dev-windows-mingw-debug",
+            "displayName": "Windows (MinGW) - Debug",
+            "description": "Windows fallback preset using MinGW Makefiles.",
+            "inherits": "base",
             "generator": "MinGW Makefiles",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-windows-mingw-release",
+            "displayName": "Windows (MinGW) - Release",
+            "description": "Release preset for MinGW on Windows.",
+            "inherits": "dev-windows-mingw-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "dev-windows-msvc",
+            "displayName": "Windows (MSVC + vcpkg)",
+            "description": "MSVC preset (requires VCPKG_ROOT for PThreads4W).",
+            "inherits": "base",
+            "generator": "Visual Studio 17 2022",
+            "architecture": {
+                "value": "x64"
+            },
+            "toolset": {
+                "value": "host=x64"
+            },
+            "condition": {
+                "type": "allOf",
+                "conditions": [
+                    {
+                        "type": "equals",
+                        "lhs": "${hostSystemName}",
+                        "rhs": "Windows"
+                    },
+                    {
+                        "type": "notEquals",
+                        "lhs": "$env{VCPKG_ROOT}",
+                        "rhs": ""
+                    }
+                ]
+            },
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        },
+        {
+            "name": "mingw",
+            "displayName": "MinGW Makefiles (legacy)",
+            "description": "Legacy preset name kept for existing scripts.",
+            "inherits": "dev-windows-mingw-release",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
@@ -13,19 +129,10 @@
         },
         {
             "name": "msvc",
-            "displayName": "MSVC 2022",
-            "description": "Generate build files with Visual Studio 17 2022 (x64)",
-            "generator": "Visual Studio 17 2022",
-            "binaryDir": "${sourceDir}/build-msvc",
-            "architecture": {
-                "value": "x64"
-            },
-            "toolset": {
-                "value": "host=x64"
-            },
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-            }
+            "displayName": "MSVC 2022 (legacy)",
+            "description": "Legacy preset name kept for existing scripts.",
+            "inherits": "dev-windows-msvc",
+            "binaryDir": "${sourceDir}/build-msvc"
         },
         {
             "name": "package-smoke-vendored",
@@ -76,6 +183,40 @@
         }
     ],
     "buildPresets": [
+        {
+            "name": "dev-linux-debug",
+            "configurePreset": "dev-linux-debug"
+        },
+        {
+            "name": "dev-linux-release",
+            "configurePreset": "dev-linux-release"
+        },
+        {
+            "name": "dev-macos-debug",
+            "configurePreset": "dev-macos-debug"
+        },
+        {
+            "name": "dev-macos-release",
+            "configurePreset": "dev-macos-release"
+        },
+        {
+            "name": "dev-windows-mingw-debug",
+            "configurePreset": "dev-windows-mingw-debug"
+        },
+        {
+            "name": "dev-windows-mingw-release",
+            "configurePreset": "dev-windows-mingw-release"
+        },
+        {
+            "name": "dev-windows-msvc-debug",
+            "configurePreset": "dev-windows-msvc",
+            "configuration": "Debug"
+        },
+        {
+            "name": "dev-windows-msvc-release",
+            "configurePreset": "dev-windows-msvc",
+            "configuration": "Release"
+        },
         {
             "name": "mingw",
             "configurePreset": "mingw"
@@ -138,12 +279,76 @@
     ],
     "testPresets": [
         {
+            "name": "dev-linux-debug",
+            "configurePreset": "dev-linux-debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-linux-release",
+            "configurePreset": "dev-linux-release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-macos-debug",
+            "configurePreset": "dev-macos-debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-macos-release",
+            "configurePreset": "dev-macos-release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-windows-mingw-debug",
+            "configurePreset": "dev-windows-mingw-debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-windows-mingw-release",
+            "configurePreset": "dev-windows-mingw-release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-windows-msvc-debug",
+            "configurePreset": "dev-windows-msvc",
+            "configuration": "Debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "dev-windows-msvc-release",
+            "configurePreset": "dev-windows-msvc",
+            "configuration": "Release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
             "name": "mingw",
-            "configurePreset": "mingw"
+            "configurePreset": "mingw",
+            "output": {
+                "outputOnFailure": true
+            }
         },
         {
             "name": "msvc",
-            "configurePreset": "msvc"
+            "configurePreset": "msvc",
+            "output": {
+                "outputOnFailure": true
+            }
         }
     ]
 }

--- a/cmake/dependencies/kvazaar.cmake
+++ b/cmake/dependencies/kvazaar.cmake
@@ -87,9 +87,37 @@ if(DVZ_ENABLE_KVAZAAR AND NOT DVZ_KVAZAAR_SOURCE STREQUAL "OFF")
                         add_library(kvazaar::kvazaar ALIAS kvazaar)
                     endif()
                     set_target_properties(kvazaar PROPERTIES POSITION_INDEPENDENT_CODE ON)
-                    if(WIN32)
+
+                    if(MSVC AND TARGET PThreads4W::PThreads4W)
+                        # Datoviz already selected the pthread implementation for MSVC. Reuse that
+                        # target for Kvazaar so its vendored pthread shim is not used.
+                        set(_dvz_kvz_threadwrapper_include "${_dvz_kvz_dir}/src/threadwrapper/include")
+                        foreach(_dvz_kvz_include_prop IN ITEMS INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+                            get_target_property(_dvz_kvz_include_dirs kvazaar ${_dvz_kvz_include_prop})
+                            if(_dvz_kvz_include_dirs)
+                                list(REMOVE_ITEM _dvz_kvz_include_dirs "${_dvz_kvz_threadwrapper_include}")
+                                set_property(
+                                    TARGET kvazaar PROPERTY
+                                    ${_dvz_kvz_include_prop} "${_dvz_kvz_include_dirs}")
+                            endif()
+                        endforeach()
+
+                        set_source_files_properties(
+                            "${_dvz_kvz_dir}/src/threadwrapper/src/pthread.cpp"
+                            "${_dvz_kvz_dir}/src/threadwrapper/src/semaphore.cpp"
+                            PROPERTIES HEADER_FILE_ONLY ON)
+                        target_link_libraries(kvazaar PUBLIC PThreads4W::PThreads4W)
+
+                        unset(_dvz_kvz_include_dirs)
+                        unset(_dvz_kvz_include_prop)
+                        unset(_dvz_kvz_threadwrapper_include)
+                    endif()
+
+                    get_target_property(_dvz_kvazaar_type kvazaar TYPE)
+                    if(_dvz_kvazaar_type STREQUAL "STATIC_LIBRARY")
                         target_compile_definitions(kvazaar INTERFACE KVZ_STATIC_LIB)
                     endif()
+                    unset(_dvz_kvazaar_type)
                     set(DVZ_KVAZAAR_TARGET kvazaar::kvazaar)
                     set(DVZ_HAS_KVZ 1)
                     set(DVZ_KVAZAAR_SOURCE_RESOLVED "VENDORED")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,8 +298,16 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/external/volk ${CMAKE_CURRENT_BINARY_DIR}
 
 if(DVZ_BUILD_VK OR DVZ_BUILD_CANVAS)
     find_package(Vulkan QUIET)
+
     if(NOT Vulkan_FOUND)
-        message(STATUS "Vulkan package not found; using vendored Vulkan C headers.")
+        message(WARNING "Vulkan SDK not found; falling back to vendored Vulkan headers (a Vulkan runtime loader/ICD is still required to run).")
+
+        if(NOT TARGET Vulkan::Headers)
+            add_library(Vulkan::Headers INTERFACE IMPORTED GLOBAL)
+            set_target_properties(Vulkan::Headers PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/external"
+            )
+        endif()
     endif()
 endif()
 

--- a/src/canvas/CMakeLists.txt
+++ b/src/canvas/CMakeLists.txt
@@ -26,18 +26,35 @@ file(GLOB DVZ_CANVAS_SHADER_SOURCES
 if(DVZ_CANVAS_SHADER_SOURCES)
     find_package(Python COMPONENTS Interpreter REQUIRED)
 
-    set(DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR "" CACHE FILEPATH "glslangValidator for canvas shaders")
+    set(DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR "" CACHE FILEPATH "glslangValidator or glslc for canvas shaders")
 
     if(NOT DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR)
         find_program(_dvz_shader_validator glslangValidator)
 
+        if(NOT _dvz_shader_validator)
+            find_program(_dvz_shader_validator
+                NAMES glslc
+                HINTS "$ENV{VULKAN_SDK}/bin" "$ENV{VULKAN_SDK}/Bin"
+            )
+        endif()
+
         if(_dvz_shader_validator)
-            set(DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR "${_dvz_shader_validator}" CACHE FILEPATH "glslangValidator for canvas shaders" FORCE)
+            set(DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR "${_dvz_shader_validator}" CACHE FILEPATH "glslangValidator or glslc for canvas shaders" FORCE)
         endif()
     endif()
 
     if(NOT DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR)
-        message(FATAL_ERROR "glslangValidator not found; install the tool or set DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR.")
+        message(FATAL_ERROR "glslangValidator/glslc not found; install one of them or set DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR.")
+    endif()
+
+    # glslangValidator needs -V to emit Vulkan SPIR-V; glslc does so by default.
+    get_filename_component(_dvz_shader_compiler_name "${DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR}" NAME_WE)
+    string(TOLOWER "${_dvz_shader_compiler_name}" _dvz_shader_compiler_name)
+
+    if(_dvz_shader_compiler_name STREQUAL "glslc")
+        set(_dvz_shader_compile_flags)
+    else()
+        set(_dvz_shader_compile_flags -V)
     endif()
 
     set(DVZ_CANVAS_SHADER_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders")
@@ -57,7 +74,7 @@ if(DVZ_CANVAS_SHADER_SOURCES)
             OUTPUT ${_dvz_shader_spv} ${_dvz_shader_header}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${DVZ_CANVAS_SHADER_OUT_DIR}
             COMMAND ${DVZ_CANVAS_SHADER_GLSLANG_VALIDATOR}
-            -V
+            ${_dvz_shader_compile_flags}
             ${_dvz_shader}
             -o
             ${_dvz_shader_spv}

--- a/src/canvas/swapchain_sink.c
+++ b/src/canvas/swapchain_sink.c
@@ -1345,8 +1345,15 @@ static int canvas_submit_active_slot(
     {
         dvz_submit_command(submit, cmd);
     }
+    // Signal the acquired image's render_finished semaphore, not the slot's: the present-wait
+    // semaphore must be per swapchain image (VUID-vkQueueSubmit2-semaphore-03868). The slot's
+    // in-flight fence only proves the submit finished, not that the present consuming the
+    // semaphore has executed, so a recycled slot could re-signal a still-signaled binary
+    // semaphore. Slot count == image count, so slots[image_index] doubles as per-image state.
     dvz_submit_signal(
-        submit, dvz_semaphore_handle(state->active_slot->render_finished), 0, signal_stage);
+        submit,
+        dvz_semaphore_handle(state->slots[state->active_slot->image_index].render_finished), 0,
+        signal_stage);
     dvz_submit_signal(
         submit, dvz_semaphore_handle(canvas->timeline_semaphore), wait_value,
         VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
@@ -1516,9 +1523,10 @@ static int canvas_dispatch_present(DvzCanvas* canvas, DvzCanvasSwapchain* state,
     DvzPresentStatus present_status = DVZ_PRESENT_STATUS_OK;
     if (!canvas_test_consume_forced_status(&state->test_force_present_status, &present_status))
     {
+        // Wait on the presented image's render_finished semaphore (see the submit-side note).
         present_status = dvz_swapchain_present(
             state->swapchain_wrapper, queue, index,
-            dvz_semaphore_handle(state->active_slot->render_finished));
+            dvz_semaphore_handle(state->slots[index].render_finished));
     }
     return canvas_handle_present_status(canvas, state, present_status, index);
 }

--- a/src/common/_time_utils.h
+++ b/src/common/_time_utils.h
@@ -33,10 +33,12 @@
 
 // Time utils.
 #if CC_MSVC
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
-// MSVC defines this in winsock2.h!?
+// Newer Windows SDKs may already provide timeval via winsock.h / winsock2.h.
 #if !defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
 typedef struct timeval
 {

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -134,9 +134,12 @@ void log_set_lock(log_LockFn fn) { L.lock = fn; }
 
 void log_set_fp(FILE* fp) { L.fp = fp; }
 
+static int log_level_explicitly_set;
+
 void log_set_level(int level)
 {
     // log_debug("set log level to %d", level);
+    log_level_explicitly_set = 1;
     L.level = level;
 }
 
@@ -157,6 +160,13 @@ void log_set_intercept(log_InterceptFn fn, void* udata)
 
 void log_log(int level, const char* file, int line, const char* fmt, ...)
 {
+    // On compilers without __attribute__((constructor)) (MSVC), _log_init() never runs, so the
+    // zero-initialized level stays at LOG_TRACE and floods stderr in embedded/library builds.
+    // Pick up DVZ_LOG_LEVEL lazily unless a level was already set.
+    if (!log_level_explicitly_set)
+    {
+        log_set_level_env();
+    }
     if (level < L.level)
     {
         return;

--- a/tools/vulkan-env.sh
+++ b/tools/vulkan-env.sh
@@ -69,7 +69,16 @@ if [ "${_dvz_uname}" = "Darwin" ]; then
 
     export VK_ICD_FILENAMES="${_dvz_icd_path}"
 
-    if [ -n "${DYLD_LIBRARY_PATH:-}" ]; then
+    # Backward-compatibility mode: keep prior DYLD_LIBRARY_PATH behavior unless the caller
+    # explicitly requests a sanitized Vulkan environment.
+    if [ "${DVZ_VULKAN_SANITIZE_ENV:-0}" = "1" ]; then
+        unset VK_DRIVER_FILES
+        unset VK_ADD_DRIVER_FILES
+        unset VK_LOADER_DRIVERS_SELECT
+        unset VK_LOADER_DRIVERS_DISABLE
+        unset DYLD_LIBRARY_PATH
+        echo "datoviz: using sanitized Vulkan environment (DVZ_VULKAN_SANITIZE_ENV=1)" >&2
+    elif [ -n "${DYLD_LIBRARY_PATH:-}" ]; then
         case ":${DYLD_LIBRARY_PATH}:" in
             *:"${VULKAN_SDK}/lib":*) ;;
             *) export DYLD_LIBRARY_PATH="${VULKAN_SDK}/lib:${DYLD_LIBRARY_PATH}" ;;


### PR DESCRIPTION
## Summary

This PR has a few cmake preset changes and runtime fixes that we've been carrying downstream while embedding Datoviz as a subdirectory in a larger application. Most of them are portability fixes (Windows/MSVC, macOS) and improvements for consuming Datoviz as a library. Only one change is a genuine Vulkan synchronization bug that we hit on Windows/NVIDIA.

Overall, this PR doesn't affect your typical workflow while making it easier to use as a library. Each change is independent, so feel free to suggest I open a PR for a subset of these changes. I realize 0.4-dev is in active development but hoping these changes don't conflict with your plans for datoviz. 

### CMake developer presets
Reworked `CMakePresets.json` into a cross-platform set: a hidden `base` preset plus debug/release pairs for Linux, macOS, and Windows (MinGW and MSVC), each guarded by a `hostSystemName` condition, with matching build/test presets. The old `mingw`/`msvc` names are kept as aliases so existing scripts still work. Schema bumped to v3 / CMake 3.21 to match `cmake_minimum_required`.

### Vulkan headers fallback
When `find_package(Vulkan)` fails, the build relied on the vendored headers being picked up implicitly, leaving `Vulkan::Headers` undefined even though targets link against it. Now we define an explicit `Vulkan::Headers` imported target pointing at the vendored headers, with a warning that a runtime loader/ICD is still required.

### `glslc` fallback for shader compilation
The canvas shader step hard-required `glslangValidator`; the macOS Vulkan SDK ships `glslc` instead. We now fall back to `glslc` (under `$VULKAN_SDK/bin`) and pass the right flags for whichever compiler is found (`glslc` needs no `-V`).

### Kvazaar on MSVC
Kvazaar was pulling in its own `threadwrapper` pthread shim, conflicting with the PThreads4W implementation Datoviz already selects on MSVC. When building with MSVC and PThreads4W is present, we drop Kvazaar's threadwrapper and link the same target. Also switched the `KVZ_STATIC_LIB` define from `if(WIN32)` to a check of the target's actual `TYPE`.

### `_time_utils.h`
Guard `WIN32_LEAN_AND_MEAN` with `#ifndef` so we don't redefine it when the consuming project already set it, and refresh the stale `timeval` comment.

### `tools/vulkan-env.sh`
Add an opt-in `DVZ_VULKAN_SANITIZE_ENV=1` mode that clears conflicting Vulkan loader/driver variables on macOS. Default behavior is unchanged.

### Per-image present semaphore (Vulkan bug)
The swapchain sink signaled/waited on the frame *slot's* `render_finished` semaphore, but the present-wait semaphore must be tied to the swapchain **image** (VUID-vkQueueSubmit2-semaphore-03868). A recycled slot could re-signal a still-signaled binary semaphore — tolerated by MoltenVK, but `VK_ERROR_DEVICE_LOST` within seconds on Windows/NVIDIA. Since slot count equals image count, we index by the acquired image index instead.

### Honor `DVZ_LOG_LEVEL` in embedded builds
The log level is initialized via an `__attribute__((constructor))`, which only runs on GCC/Clang. Under MSVC it never fires, leaving the level at `LOG_TRACE` and flooding stderr in release builds. `log_log()` now picks up `DVZ_LOG_LEVEL` lazily on first use unless a level was set explicitly, composing cleanly with the existing constructor.

### Reuse an existing GLFW target when embedded
When Datoviz is added via `add_subdirectory` into a project that already built GLFW, the vendored path tried to add GLFW again and failed on the duplicate target. It now reuses an existing `glfw` target, matching what the system-dependency branch already did.