### PR TITLE
agents: queue data hygiene correction

### DIFF
--- a/agents/now/START.md
+++ b/agents/now/START.md
@@ -1,6 +1,6 @@
 # Datoviz v0.4 Dispatch
 
-Status: active post-RC2 work toward RC3, then RC4 and final v0.4.0. Updated: 2026-08-27.
+Status: active post-RC2 work toward RC3, then RC4 and final v0.4.0. Updated: 2026-08-30.
 
 Use [../../AGENTS.md](../../AGENTS.md) as the mandatory entry point. This file identifies only the current route; durable contracts belong in `spec/`, public guidance belongs in `docs/`, and completed evidence belongs in release records and Git history.
 
@@ -38,6 +38,7 @@ scene frame plans -> drp2 command streams -> vklite runtime -> canvas/stream fra
 18. Use [ISSUE_138_PERFORMANCE_HANDOFF.md](ISSUE_138_PERFORMANCE_HANDOFF.md) for the benchmark-first rolling-field/structured-surface performance lane and its strict RC4 versus post-v0.4 boundary.
 19. The required [RC3_LIGHTING_FOUNDATION_SLICE.md](../../spec/scene/slices/RC3_LIGHTING_FOUNDATION_SLICE.md) is complete at validated implementation head `8fd98715e`. Preserve its scene-owned panel-light and direct/indirect contracts during candidate validation; do not expand it into full PBR or the optional multi-light showcase.
 20. Use [GUI_IMPLOT_DOCKING_HANDOFF.md](GUI_IMPLOT_DOCKING_HANDOFF.md) for the non-blocking pre-RC3 official ImPlot/cimplot and declarative docking lane after PR #145 merges; finish it before candidate freeze or defer it intact without delaying RC3.
+21. Before further `data` or asset-migration work, complete the narrow corrective PR recorded under "Immediate Data Hygiene Follow-Up" in [STATUS.md](STATUS.md); preserve `datoviz/data:v0.4-dev` as the protected frozen v0.4 line and do not rename, merge, or repoint it to the unrelated historical `data:main`.
 
 ## Guardrails
 

--- a/agents/now/STATUS.md
+++ b/agents/now/STATUS.md
@@ -1,6 +1,6 @@
 # Datoviz v0.4 Status
 
-Status: active post-RC2 work toward RC3, then RC4 and final v0.4.0. Updated: 2026-08-27.
+Status: active post-RC2 work toward RC3, then RC4 and final v0.4.0. Updated: 2026-08-30.
 
 Keep this file current and short. Durable behavior belongs in `spec/`; completed campaign detail belongs in Git history, release assets, and tagged documentation.
 
@@ -23,6 +23,12 @@ The issue #137 render-product lane is complete through R9: typed panel-local pro
 Issues #139 and #140 are implemented locally under [ISSUES_139_140_HANDOFF.md](ISSUES_139_140_HANDOFF.md): physical keys remain distinct from committed UTF-8 text, and mesh replacement now uses stable scene-buffer identity, independent logical extent, explicit retirement, and atomic indexed/nonindexed transitions. Issue #138's local benchmark and bounded corrections are also complete under [ISSUE_138_PERFORMANCE_HANDOFF.md](ISSUE_138_PERFORMANCE_HANDOFF.md): exact unchanged indices are not uploaded again, and valid retained surface grids use the measured finite-difference normal kernel. Optional sampled-field foundations remain non-blocking RC4 candidates, while GPU-displaced structured surfaces remain post-v0.4.
 
 The validated implementation head builds and passes 1,128/1,128 validation-enabled native tests, 95/95 DRP2 contract tests, 125/125 fixtures, 100/100 runtime-vklite, 34/34 slow/recovery cases, all seven bounded presentation paths, specifications, WebGPU, bindings, example manifests, generated docs/snippets/build, and the Vulkan course smoke. Full-tree static analysis is dispositioned; CPU sanitizer coverage is green for the new non-driver fixes, while Vulkan-backed sanitizer teardown remains inconclusive. Exact candidate artifact and platform proof remain separate release gates.
+
+## Immediate Data Hygiene Follow-Up
+
+The next agent touching `data` or asset migration must first prepare and land one focused corrective PR. Update the stale `tools/data/DATA_POLICY.md` commands that target the unrelated historical `data:main`; the live transitional branch is the protected `datoviz/data:v0.4-dev`. State that this branch is frozen except for explicitly approved recovery or migration work, require `python3 tools/check_submodule_reachability.py data` before any parent gitlink publication, and record `3c862beb2e9885f5af9dc624dc22a6d5bb856026` as the current frozen v0.4 tip while preserving `a9542d20f2d29aecb9518738f6b7ba1914b63997` as historical cutover evidence.
+
+Keep that PR documentation-only and exclude the `data` gitlink, binary assets, catalog implementation, branch rename, history merge, and broader migration. Validate with `python3 tools/check_submodule_reachability.py data`, the focused documentation checks, `git diff --check`, `git status --short`, and inspection of the staged set. Land through a PR because `Submodule reachability / data` is required on `main`; do not weaken or bypass rulesets `21825397` (`datoviz/data:v0.4-dev` deletion/non-fast-forward protection) or `21825416` (required parent reachability check).
 
 ## Remaining RC3 Gates
 


### PR DESCRIPTION
## Summary

- route future data and asset-migration work through one narrow corrective PR
- preserve the protected `datoviz/data:v0.4-dev` line instead of the unrelated historical `data:main`
- record the exact scope, frozen and historical commits, validation, exclusions, and active rulesets

## Validation

- `python3 tools/check_submodule_reachability.py data`
- `git diff --check`
