### PR TITLE
docs: freeze transitional data branch policy

### DIFF
--- a/agents/now/START.md
+++ b/agents/now/START.md
@@ -38,7 +38,7 @@ scene frame plans -> drp2 command streams -> vklite runtime -> canvas/stream fra
 18. Use [ISSUE_138_PERFORMANCE_HANDOFF.md](ISSUE_138_PERFORMANCE_HANDOFF.md) for the benchmark-first rolling-field/structured-surface performance lane and its strict RC4 versus post-v0.4 boundary.
 19. The required [RC3_LIGHTING_FOUNDATION_SLICE.md](../../spec/scene/slices/RC3_LIGHTING_FOUNDATION_SLICE.md) is complete at validated implementation head `8fd98715e`. Preserve its scene-owned panel-light and direct/indirect contracts during candidate validation; do not expand it into full PBR or the optional multi-light showcase.
 20. Use [GUI_IMPLOT_DOCKING_HANDOFF.md](GUI_IMPLOT_DOCKING_HANDOFF.md) for the non-blocking pre-RC3 official ImPlot/cimplot and declarative docking lane after PR #145 merges; finish it before candidate freeze or defer it intact without delaying RC3.
-21. Before further `data` or asset-migration work, complete the narrow corrective PR recorded under "Immediate Data Hygiene Follow-Up" in [STATUS.md](STATUS.md); preserve `datoviz/data:v0.4-dev` as the protected frozen v0.4 line and do not rename, merge, or repoint it to the unrelated historical `data:main`.
+21. Use [../../spec/data/ASSET_ARCHITECTURE.md](../../spec/data/ASSET_ARCHITECTURE.md) for the approved no-LFS asset catalog and active-submodule retirement plan. Preserve `datoviz/data:v0.4-dev` as the protected frozen v0.4 line during migration; do not rename, merge, or repoint it to the unrelated historical `data:main`.
 
 ## Guardrails
 

--- a/agents/now/STATUS.md
+++ b/agents/now/STATUS.md
@@ -24,11 +24,7 @@ Issues #139 and #140 are implemented locally under [ISSUES_139_140_HANDOFF.md](I
 
 The validated implementation head builds and passes 1,128/1,128 validation-enabled native tests, 95/95 DRP2 contract tests, 125/125 fixtures, 100/100 runtime-vklite, 34/34 slow/recovery cases, all seven bounded presentation paths, specifications, WebGPU, bindings, example manifests, generated docs/snippets/build, and the Vulkan course smoke. Full-tree static analysis is dispositioned; CPU sanitizer coverage is green for the new non-driver fixes, while Vulkan-backed sanitizer teardown remains inconclusive. Exact candidate artifact and platform proof remain separate release gates.
 
-## Immediate Data Hygiene Follow-Up
-
-The next agent touching `data` or asset migration must first prepare and land one focused corrective PR. Update the stale `tools/data/DATA_POLICY.md` commands that target the unrelated historical `data:main`; the live transitional branch is the protected `datoviz/data:v0.4-dev`. State that this branch is frozen except for explicitly approved recovery or migration work, require `python3 tools/check_submodule_reachability.py data` before any parent gitlink publication, and record `3c862beb2e9885f5af9dc624dc22a6d5bb856026` as the current frozen v0.4 tip while preserving `a9542d20f2d29aecb9518738f6b7ba1914b63997` as historical cutover evidence.
-
-Keep that PR documentation-only and exclude the `data` gitlink, binary assets, catalog implementation, branch rename, history merge, and broader migration. Validate with `python3 tools/check_submodule_reachability.py data`, the focused documentation checks, `git diff --check`, `git status --short`, and inspection of the staged set. Land through a PR because `Submodule reachability / data` is required on `main`; do not weaken or bypass rulesets `21825397` (`datoviz/data:v0.4-dev` deletion/non-fast-forward protection) or `21825416` (required parent reachability check).
+The missing current `data` commit and LFS payload were recovered at `3c862beb2e9885f5af9dc624dc22a6d5bb856026`. The protected `datoviz/data:v0.4-dev` branch is the frozen transitional v0.4 line; unrelated historical `data:main` remains unchanged. Parent gitlink reachability is enforced on pull requests and `main` by the required `Submodule reachability / data` check, while the durable catalog migration and active-submodule retirement plan remains [ASSET_ARCHITECTURE.md](../../spec/data/ASSET_ARCHITECTURE.md).
 
 ## Remaining RC3 Gates
 

--- a/spec/data/ASSET_ARCHITECTURE.md
+++ b/spec/data/ASSET_ARCHITECTURE.md
@@ -287,7 +287,7 @@ Catalog implementation, asset publication, gallery migration, and final submodul
 2. Record every distinct data gitlink referenced by a released parent tag and the LFS objects required for later snapshot export, without making complete legacy reconstruction a branch-cutover gate.
 3. Classify every current binary as runtime-required, test fixture, stable generated core payload, package artifact, redistributable example bundle, upstream-only dataset, gallery media, release evidence, local diagnostic output, or obsolete/duplicate.
 4. Audit current fonts, textures, prepared datasets, and generated media for source/license gaps, privacy or scientific-data restrictions, dirty producer states, and honest reproducibility status.
-5. Preserve hashes for the pinned `a9542d2` v0.4 data snapshot so later publication can prove byte identity.
+5. Preserve hashes for historical cutover snapshot `a9542d20f2d29aecb9518738f6b7ba1914b63997` and current frozen v0.4 tip `3c862beb2e9885f5af9dc624dc22a6d5bb856026` so later publication and legacy reconstruction can prove byte identity.
 
 Exit gate: every current path has one declared destination or explicit retirement decision, every released data gitlink is enumerated for the parallel preservation lane, and no file is migrated solely because it exists.
 

--- a/tools/data/DATA_POLICY.md
+++ b/tools/data/DATA_POLICY.md
@@ -1,6 +1,7 @@
 # Example Data Policy
 
-This policy covers example-data bundles prepared by `tools/data/*` and stored in the `data` submodule.
+This policy covers example-data bundles prepared by `tools/data/*` and stored in the transitional `data` submodule. The protected `datoviz/data:v0.4-dev` branch is frozen at `3c862beb2e9885f5af9dc624dc22a6d5bb856026` except for explicitly approved recovery or migration work; do not add active datasets or gallery output while the catalog migration is pending, and do not rename, merge, or repoint it to the unrelated historical `data:main` line.
+
 Do not edit scripts or data files when the task is documentation-only.
 
 The canonical v0.4 data-branch strategy is in
@@ -18,8 +19,7 @@ change includes both data and parent-repo references, keep the order explicit:
 2. Return to the parent repository and stage the updated `data` submodule pointer plus any parent-repo
    code or documentation that depends on it.
 3. Commit the parent repository only after the submodule commit exists locally.
-4. Do not push either repository unless the user explicitly asks for a push. If a push is requested later,
-   push the data submodule commit first, then the parent repository commit that references it.
+4. Do not push either repository unless the user explicitly asks for a push. If a push is requested later, push the approved data commit to `datoviz/data:v0.4-dev`, run `python3 tools/check_submodule_reachability.py data` from the parent repository, then push the parent repository commit that references it.
 
 Useful status checks:
 
@@ -65,14 +65,15 @@ being promoted into the data submodule.
 
 Manifests and provenance files are normal text files and should not be stored through LFS.
 
-When a push is eventually requested, upload LFS objects before pushing the parent repository pointer:
+When an explicitly approved recovery or migration push is eventually requested, upload LFS objects and fast-forward the protected v0.4 data branch before publishing the parent repository pointer:
 
 ```bash
 cd data
 git lfs status
-git lfs push origin main
-git push origin main
+git lfs push origin HEAD
+git push origin HEAD:v0.4-dev
 cd ..
+python3 tools/check_submodule_reachability.py data
 git push
 ```
 


### PR DESCRIPTION
## Summary

- identify protected `datoviz/data:v0.4-dev` as the frozen transitional v0.4 line and preserve unrelated historical `data:main`
- correct recovery publication commands to upload exact detached `HEAD`, fast-forward `v0.4-dev`, and verify parent gitlink reachability
- record current frozen tip `3c862be` alongside historical cutover snapshot `a9542d2`
- resolve the temporary agent handoff into the durable asset-architecture route

## Scope

Documentation only. No `data` gitlink, binary asset, branch history, catalog implementation, or migration code changes.

## Validation

- `python3 tools/check_submodule_reachability.py data`
- `just spec-check`
- `just docs-check-generated`
- `just docs-build-check`
- `git diff --check`
- staged payload inspection
