### PR TITLE
Clip path strokes against the frustum before projecting

### DIFF
--- a/src/scene/shaders/glsl/path.vert
+++ b/src/scene/shaders/glsl/path.vert
@@ -68,6 +68,20 @@ void main()
     bool hasPrev = (inPathFlags & HAS_PREV) != 0u;
     bool hasNext = (inPathFlags & HAS_NEXT) != 0u;
     float side = sideNegative ? -1.0 : 1.0;
+    float strokeWidth = max(inLineWidth, 0.0);
+    float lateralMarginPx = dvz_stroke_outer_half_width(strokeWidth);
+    if (!hasPrev)
+    {
+        int startCap = int(round(material.params.x));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_extension(startCap, strokeWidth));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_half_width(startCap, strokeWidth));
+    }
+    if (!hasNext)
+    {
+        int endCap = int(round(material.params.y));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_extension(endCap, strokeWidth));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_half_width(endCap, strokeWidth));
+    }
 
     vec4 p0Clip = transform(inPositionPrev);
     vec4 p1Clip = transform(inPositionStart);
@@ -79,7 +93,7 @@ void main()
     // discarding it. Segment visuals already clip here; paths must too.
     vec4 startOriginal = p1Clip;
     vec4 endOriginal = p2Clip;
-    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip))
+    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip, lateralMarginPx, viewport.rect.zw))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragColor = vec4(0.0);
@@ -124,7 +138,6 @@ void main()
     vec2 n1 = vec2(-v1.y, v1.x);
     vec2 n2 = vec2(-v2.y, v2.x);
 
-    float strokeWidth = max(inLineWidth, 0.0);
     float halfWidth = dvz_stroke_outer_half_width(strokeWidth);
     int joinType = int(round(material.params.z));
     float miterLimit = max(material.params.w, 1.0);

--- a/src/scene/shaders/glsl/path.vert
+++ b/src/scene/shaders/glsl/path.vert
@@ -73,6 +73,41 @@ void main()
     vec4 p1Clip = transform(inPositionStart);
     vec4 p2Clip = transform(inPositionEnd);
     vec4 p3Clip = transform(inPositionNext);
+
+    // Nothing may be projected before it is clipped: deviceClipToTopLeftPixel()
+    // mirrors a behind-camera vertex through the viewport centre rather than
+    // discarding it. Segment visuals already clip here; paths must too.
+    vec4 startOriginal = p1Clip;
+    vec4 endOriginal = p2Clip;
+    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip))
+    {
+        gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
+        fragColor = vec4(0.0);
+        fragCoord = vec2(0.0);
+        fragLength = 0.0;
+        fragLineWidth = 0.0;
+        fragHasPrev = 0.0;
+        fragHasNext = 0.0;
+        fragBevelDistance = vec2(0.0);
+        fragJoinSplitDistance = 0.0;
+        return;
+    }
+    // An end the frustum cut is not a join and not a cap: the neighbour is on
+    // the far side of the clip, so it ends flat on the boundary.
+    bool startClipped = p1Clip != startOriginal;
+    bool endClipped = p2Clip != endOriginal;
+    bool joinPrev = hasPrev && !startClipped;
+    bool joinNext = hasNext && !endClipped;
+    // The core segment now sits in front of the near plane, so these only pull
+    // the neighbour in; they never move p1Clip or p2Clip back.
+    if (joinPrev)
+        joinPrev = dvz_stroke_clip_near(p0Clip, p1Clip);
+    if (joinNext)
+        joinNext = dvz_stroke_clip_near(p3Clip, p2Clip);
+    // A cap belongs only to a real path end, never to a clip boundary.
+    hasPrev = hasPrev || startClipped;
+    hasNext = hasNext || endClipped;
+
     vec2 p0 = deviceClipToTopLeftPixel(p0Clip);
     vec2 p1 = deviceClipToTopLeftPixel(p1Clip);
     vec2 p2 = deviceClipToTopLeftPixel(p2Clip);
@@ -81,9 +116,9 @@ void main()
     vec2 v0 = safeNormalize(p1 - p0, vec2(1.0, 0.0));
     vec2 v1 = safeNormalize(p2 - p1, v0);
     vec2 v2 = safeNormalize(p3 - p2, v1);
-    if (!hasPrev)
+    if (!joinPrev)
         v0 = v1;
-    if (!hasNext)
+    if (!joinNext)
         v2 = v1;
     vec2 n0 = vec2(-v0.y, v0.x);
     vec2 n1 = vec2(-v1.y, v1.x);

--- a/src/scene/shaders/glsl/path_query_u32.vert
+++ b/src/scene/shaders/glsl/path_query_u32.vert
@@ -68,6 +68,20 @@ void main()
     bool hasPrev = (inPathFlags & HAS_PREV) != 0u;
     bool hasNext = (inPathFlags & HAS_NEXT) != 0u;
     float side = sideNegative ? -1.0 : 1.0;
+    float strokeWidth = max(inLineWidth, 0.0);
+    float lateralMarginPx = dvz_stroke_outer_half_width(strokeWidth);
+    if (!hasPrev)
+    {
+        int startCap = int(round(material.params.x));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_extension(startCap, strokeWidth));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_half_width(startCap, strokeWidth));
+    }
+    if (!hasNext)
+    {
+        int endCap = int(round(material.params.y));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_extension(endCap, strokeWidth));
+        lateralMarginPx = max(lateralMarginPx, dvz_stroke_cap_half_width(endCap, strokeWidth));
+    }
 
     vec4 p0Clip = transform(inPositionPrev);
     vec4 p1Clip = transform(inPositionStart);
@@ -79,7 +93,7 @@ void main()
     // behind-camera vertex through the viewport centre rather than dropping it.
     vec4 startOriginal = p1Clip;
     vec4 endOriginal = p2Clip;
-    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip))
+    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip, lateralMarginPx, viewport.rect.zw))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragCoord = vec2(0.0);
@@ -119,7 +133,6 @@ void main()
     vec2 n1 = vec2(-v1.y, v1.x);
     vec2 n2 = vec2(-v2.y, v2.x);
 
-    float strokeWidth = max(inLineWidth, 0.0);
     float halfWidth = dvz_stroke_outer_half_width(strokeWidth);
     int joinType = int(round(material.params.z));
     float miterLimit = max(material.params.w, 1.0);

--- a/src/scene/shaders/glsl/path_query_u32.vert
+++ b/src/scene/shaders/glsl/path_query_u32.vert
@@ -73,6 +73,36 @@ void main()
     vec4 p1Clip = transform(inPositionStart);
     vec4 p2Clip = transform(inPositionEnd);
     vec4 p3Clip = transform(inPositionNext);
+
+    // Picking has to agree with rendering, so this mirrors path.vert exactly:
+    // clip before projecting, because deviceClipToTopLeftPixel() mirrors a
+    // behind-camera vertex through the viewport centre rather than dropping it.
+    vec4 startOriginal = p1Clip;
+    vec4 endOriginal = p2Clip;
+    if (!dvz_stroke_clip_to_view(p1Clip, p2Clip))
+    {
+        gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
+        fragCoord = vec2(0.0);
+        fragLength = 0.0;
+        fragLineWidth = 0.0;
+        fragHasPrev = 0.0;
+        fragHasNext = 0.0;
+        fragBevelDistance = vec2(0.0);
+        fragJoinSplitDistance = 0.0;
+        fragId = inId;
+        return;
+    }
+    bool startClipped = p1Clip != startOriginal;
+    bool endClipped = p2Clip != endOriginal;
+    bool joinPrev = hasPrev && !startClipped;
+    bool joinNext = hasNext && !endClipped;
+    if (joinPrev)
+        joinPrev = dvz_stroke_clip_near(p0Clip, p1Clip);
+    if (joinNext)
+        joinNext = dvz_stroke_clip_near(p3Clip, p2Clip);
+    hasPrev = hasPrev || startClipped;
+    hasNext = hasNext || endClipped;
+
     vec2 p0 = deviceClipToTopLeftPixel(p0Clip);
     vec2 p1 = deviceClipToTopLeftPixel(p1Clip);
     vec2 p2 = deviceClipToTopLeftPixel(p2Clip);
@@ -81,9 +111,9 @@ void main()
     vec2 v0 = safeNormalize(p1 - p0, vec2(1.0, 0.0));
     vec2 v1 = safeNormalize(p2 - p1, v0);
     vec2 v2 = safeNormalize(p3 - p2, v1);
-    if (!hasPrev)
+    if (!joinPrev)
         v0 = v1;
-    if (!hasNext)
+    if (!joinNext)
         v2 = v1;
     vec2 n0 = vec2(-v0.y, v0.x);
     vec2 n1 = vec2(-v1.y, v1.x);

--- a/src/scene/shaders/glsl/segment.vert
+++ b/src/scene/shaders/glsl/segment.vert
@@ -28,7 +28,17 @@ void main()
 {
     vec4 startClip = transform(inPositionStart);
     vec4 endClip = transform(inPositionEnd);
-    if (!dvz_stroke_clip_to_view(startClip, endClip))
+    float strokeWidth = max(inLineWidth, 0.0);
+    int startCap = int(round(material.params.x));
+    int endCap = int(round(material.params.y));
+    float startExtension = dvz_stroke_cap_extension(startCap, strokeWidth);
+    float endExtension = dvz_stroke_cap_extension(endCap, strokeWidth);
+    float startHalfWidth = dvz_stroke_cap_half_width(startCap, strokeWidth);
+    float endHalfWidth = dvz_stroke_cap_half_width(endCap, strokeWidth);
+    float lateralMarginPx =
+        max(max(startExtension, endExtension), max(startHalfWidth, endHalfWidth));
+    if (!dvz_stroke_clip_to_view(
+            startClip, endClip, lateralMarginPx, viewport.rect.zw))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragColor = vec4(0.0);
@@ -49,13 +59,6 @@ void main()
         tangent /= lengthPx;
     vec2 normal = vec2(-tangent.y, tangent.x);
 
-    float strokeWidth = max(inLineWidth, 0.0);
-    int startCap = int(round(material.params.x));
-    int endCap = int(round(material.params.y));
-    float startExtension = dvz_stroke_cap_extension(startCap, strokeWidth);
-    float endExtension = dvz_stroke_cap_extension(endCap, strokeWidth);
-    float startHalfWidth = dvz_stroke_cap_half_width(startCap, strokeWidth);
-    float endHalfWidth = dvz_stroke_cap_half_width(endCap, strokeWidth);
     int vertex = gl_VertexIndex & 3;
     vec2 pixel = startPx;
     vec4 clip = startClip;

--- a/src/scene/shaders/glsl/segment.vert
+++ b/src/scene/shaders/glsl/segment.vert
@@ -24,46 +24,11 @@ layout(location = 1) out vec2 fragCoord;
 layout(location = 2) out float fragLength;
 layout(location = 3) out float fragLineWidth;
 
-const float CLIP_EPS = 1e-5;
-
-bool clipSegmentPlane(inout vec4 startClip, inout vec4 endClip, float startDist, float endDist)
-{
-    if (startDist < 0.0 && endDist < 0.0)
-        return false;
-    if (startDist < 0.0 || endDist < 0.0)
-    {
-        float t = startDist / (startDist - endDist);
-        vec4 clipped = mix(startClip, endClip, clamp(t, 0.0, 1.0));
-        if (startDist < 0.0)
-            startClip = clipped;
-        else
-            endClip = clipped;
-    }
-    return true;
-}
-
-bool clipSegmentToView(inout vec4 startClip, inout vec4 endClip)
-{
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - CLIP_EPS, endClip.w - CLIP_EPS))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.x + startClip.w, endClip.x + endClip.w))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - startClip.x, endClip.w - endClip.x))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.y + startClip.w, endClip.y + endClip.w))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - startClip.y, endClip.w - endClip.y))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.z, endClip.z))
-        return false;
-    return clipSegmentPlane(startClip, endClip, startClip.w - startClip.z, endClip.w - endClip.z);
-}
-
 void main()
 {
     vec4 startClip = transform(inPositionStart);
     vec4 endClip = transform(inPositionEnd);
-    if (!clipSegmentToView(startClip, endClip))
+    if (!dvz_stroke_clip_to_view(startClip, endClip))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragColor = vec4(0.0);

--- a/src/scene/shaders/glsl/segment_query_u32.vert
+++ b/src/scene/shaders/glsl/segment_query_u32.vert
@@ -28,7 +28,17 @@ void main()
 {
     vec4 startClip = transform(inPositionStart);
     vec4 endClip = transform(inPositionEnd);
-    if (!dvz_stroke_clip_to_view(startClip, endClip))
+    float strokeWidth = max(inLineWidth, 0.0);
+    int startCap = int(round(material.params.x));
+    int endCap = int(round(material.params.y));
+    float startExtension = dvz_stroke_cap_extension(startCap, strokeWidth);
+    float endExtension = dvz_stroke_cap_extension(endCap, strokeWidth);
+    float startHalfWidth = dvz_stroke_cap_half_width(startCap, strokeWidth);
+    float endHalfWidth = dvz_stroke_cap_half_width(endCap, strokeWidth);
+    float lateralMarginPx =
+        max(max(startExtension, endExtension), max(startHalfWidth, endHalfWidth));
+    if (!dvz_stroke_clip_to_view(
+            startClip, endClip, lateralMarginPx, viewport.rect.zw))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragCoord = vec2(0.0);
@@ -49,13 +59,6 @@ void main()
         tangent /= lengthPx;
     vec2 normal = vec2(-tangent.y, tangent.x);
 
-    float strokeWidth = max(inLineWidth, 0.0);
-    int startCap = int(round(material.params.x));
-    int endCap = int(round(material.params.y));
-    float startExtension = dvz_stroke_cap_extension(startCap, strokeWidth);
-    float endExtension = dvz_stroke_cap_extension(endCap, strokeWidth);
-    float startHalfWidth = dvz_stroke_cap_half_width(startCap, strokeWidth);
-    float endHalfWidth = dvz_stroke_cap_half_width(endCap, strokeWidth);
     int vertex = gl_VertexIndex & 3;
     vec2 pixel = startPx;
     vec4 clip = startClip;

--- a/src/scene/shaders/glsl/segment_query_u32.vert
+++ b/src/scene/shaders/glsl/segment_query_u32.vert
@@ -24,46 +24,11 @@ layout(location = 1) out float fragLength;
 layout(location = 2) out float fragLineWidth;
 layout(location = 3) flat out uint fragId;
 
-const float CLIP_EPS = 1e-5;
-
-bool clipSegmentPlane(inout vec4 startClip, inout vec4 endClip, float startDist, float endDist)
-{
-    if (startDist < 0.0 && endDist < 0.0)
-        return false;
-    if (startDist < 0.0 || endDist < 0.0)
-    {
-        float t = startDist / (startDist - endDist);
-        vec4 clipped = mix(startClip, endClip, clamp(t, 0.0, 1.0));
-        if (startDist < 0.0)
-            startClip = clipped;
-        else
-            endClip = clipped;
-    }
-    return true;
-}
-
-bool clipSegmentToView(inout vec4 startClip, inout vec4 endClip)
-{
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - CLIP_EPS, endClip.w - CLIP_EPS))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.x + startClip.w, endClip.x + endClip.w))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - startClip.x, endClip.w - endClip.x))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.y + startClip.w, endClip.y + endClip.w))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.w - startClip.y, endClip.w - endClip.y))
-        return false;
-    if (!clipSegmentPlane(startClip, endClip, startClip.z, endClip.z))
-        return false;
-    return clipSegmentPlane(startClip, endClip, startClip.w - startClip.z, endClip.w - endClip.z);
-}
-
 void main()
 {
     vec4 startClip = transform(inPositionStart);
     vec4 endClip = transform(inPositionEnd);
-    if (!clipSegmentToView(startClip, endClip))
+    if (!dvz_stroke_clip_to_view(startClip, endClip))
     {
         gl_Position = vec4(2.0, 2.0, 1.0, 1.0);
         fragCoord = vec2(0.0);

--- a/src/scene/shaders/glsl/stroke.glsl
+++ b/src/scene/shaders/glsl/stroke.glsl
@@ -41,21 +41,31 @@ bool dvz_stroke_clip_near(inout vec4 startClip, inout vec4 endClip)
 }
 
 
-bool dvz_stroke_clip_to_view(inout vec4 startClip, inout vec4 endClip)
+bool dvz_stroke_clip_to_view(
+    inout vec4 startClip, inout vec4 endClip, float lateralMarginPx, vec2 viewportSize)
 {
     if (!dvz_stroke_clip_near(startClip, endClip))
         return false;
+    // The centerline is not the rendered primitive. Expand only the lateral
+    // planes by the screen-space footprint so a visible stroke or cap is not
+    // rejected before its analytic quad is built.
+    vec2 lateralMarginNdc =
+        2.0 * max(lateralMarginPx, 0.0) / max(viewportSize, vec2(1.0));
     if (!dvz_stroke_clip_plane(
-            startClip, endClip, startClip.x + startClip.w, endClip.x + endClip.w))
+            startClip, endClip, startClip.x + (1.0 + lateralMarginNdc.x) * startClip.w,
+            endClip.x + (1.0 + lateralMarginNdc.x) * endClip.w))
         return false;
     if (!dvz_stroke_clip_plane(
-            startClip, endClip, startClip.w - startClip.x, endClip.w - endClip.x))
+            startClip, endClip, (1.0 + lateralMarginNdc.x) * startClip.w - startClip.x,
+            (1.0 + lateralMarginNdc.x) * endClip.w - endClip.x))
         return false;
     if (!dvz_stroke_clip_plane(
-            startClip, endClip, startClip.y + startClip.w, endClip.y + endClip.w))
+            startClip, endClip, startClip.y + (1.0 + lateralMarginNdc.y) * startClip.w,
+            endClip.y + (1.0 + lateralMarginNdc.y) * endClip.w))
         return false;
     if (!dvz_stroke_clip_plane(
-            startClip, endClip, startClip.w - startClip.y, endClip.w - endClip.y))
+            startClip, endClip, (1.0 + lateralMarginNdc.y) * startClip.w - startClip.y,
+            (1.0 + lateralMarginNdc.y) * endClip.w - endClip.y))
         return false;
     if (!dvz_stroke_clip_plane(startClip, endClip, startClip.z, endClip.z))
         return false;

--- a/src/scene/shaders/glsl/stroke.glsl
+++ b/src/scene/shaders/glsl/stroke.glsl
@@ -2,6 +2,67 @@ const int DVZ_STROKE_CAP_NONE = 0;
 const int DVZ_STROKE_CAP_TRIANGLE_OUT = 3;
 const int DVZ_STROKE_CAP_BUTT = 5;
 
+const float DVZ_STROKE_CLIP_EPS = 1e-5;
+
+
+/* Screen-space stroking projects its endpoints through
+ * deviceClipToTopLeftPixel(), which divides by max(abs(w), 1e-6). That abs()
+ * does not clip a vertex behind the camera, it mirrors it through the viewport
+ * centre, and the quad built from that pixel then stretches across the view.
+ * Every stroke shader therefore clips its segment in clip space first.
+ */
+bool dvz_stroke_clip_plane(
+    inout vec4 startClip, inout vec4 endClip, float startDist, float endDist)
+{
+    if (startDist < 0.0 && endDist < 0.0)
+        return false;
+    if (startDist < 0.0 || endDist < 0.0)
+    {
+        float t = startDist / (startDist - endDist);
+        vec4 clipped = mix(startClip, endClip, clamp(t, 0.0, 1.0));
+        if (startDist < 0.0)
+            startClip = clipped;
+        else
+            endClip = clipped;
+    }
+    return true;
+}
+
+
+/* Clip against the near plane alone. Join neighbours use this: they only supply
+ * a direction, and the side planes would slide them along their own segment and
+ * bend the join away from the geometry it belongs to.
+ */
+bool dvz_stroke_clip_near(inout vec4 startClip, inout vec4 endClip)
+{
+    return dvz_stroke_clip_plane(
+        startClip, endClip, startClip.w - DVZ_STROKE_CLIP_EPS,
+        endClip.w - DVZ_STROKE_CLIP_EPS);
+}
+
+
+bool dvz_stroke_clip_to_view(inout vec4 startClip, inout vec4 endClip)
+{
+    if (!dvz_stroke_clip_near(startClip, endClip))
+        return false;
+    if (!dvz_stroke_clip_plane(
+            startClip, endClip, startClip.x + startClip.w, endClip.x + endClip.w))
+        return false;
+    if (!dvz_stroke_clip_plane(
+            startClip, endClip, startClip.w - startClip.x, endClip.w - endClip.x))
+        return false;
+    if (!dvz_stroke_clip_plane(
+            startClip, endClip, startClip.y + startClip.w, endClip.y + endClip.w))
+        return false;
+    if (!dvz_stroke_clip_plane(
+            startClip, endClip, startClip.w - startClip.y, endClip.w - endClip.y))
+        return false;
+    if (!dvz_stroke_clip_plane(startClip, endClip, startClip.z, endClip.z))
+        return false;
+    return dvz_stroke_clip_plane(
+        startClip, endClip, startClip.w - startClip.z, endClip.w - endClip.z);
+}
+
 
 float dvz_stroke_alpha(float distance, float lineWidth)
 {

--- a/src/scene/tests/app.c
+++ b/src/scene/tests/app.c
@@ -3427,6 +3427,162 @@ int test_app_offscreen_has_nonblank_pixels(TstContext* suite, const TstCase* ite
 
 
 /**
+ * Render one two-point path into a 96x96 offscreen capture.
+ *
+ * @param suite the test suite
+ * @param positions two object-space path positions
+ * @param stroke_width screen-space stroke width in pixels
+ * @param camera optional perspective camera descriptor
+ * @param out output capture whose RGBA storage is owned by the caller
+ * @return 0 on success, -1 when GPU setup is unavailable
+ */
+static int _app_capture_two_point_path(
+    TstContext* suite, const vec3 positions[2], float stroke_width,
+    const DvzCameraDesc* camera, AppRgbaCapture* out)
+{
+    ANN(suite);
+    ANN(positions);
+    ANN(out);
+    *out = (AppRgbaCapture){0};
+
+    DvzScene* scene = dvz_scene();
+    AT(scene != NULL);
+    DvzFigure* figure = dvz_figure(scene, 96, 96, 0);
+    AT(figure != NULL);
+    DvzPanel* panel = dvz_panel(figure, &(DvzPanelDesc){0.0f, 0.0f, 1.0f, 1.0f});
+    AT(panel != NULL);
+    if (camera != NULL)
+        AT(dvz_panel_set_camera_desc(panel, camera) == DVZ_OK);
+    dvz_panel_set_background_color(panel, dvz_color_rgba(0, 0, 0, 255));
+
+    DvzVisual* visual = dvz_path(scene, 0);
+    AT(visual != NULL);
+    DvzColor colors[2] = {{255, 0, 0, 255}, {255, 0, 0, 255}};
+    float widths[2] = {stroke_width, stroke_width};
+    AT(dvz_visual_set_data(visual, "position", positions, 2) == DVZ_OK);
+    AT(dvz_visual_set_data(visual, "color", colors, 2) == DVZ_OK);
+    AT(dvz_visual_set_data(visual, "stroke_width_px", widths, 2) == DVZ_OK);
+    AT(dvz_path_set_caps(visual, DVZ_SEGMENT_CAP_BUTT, DVZ_SEGMENT_CAP_BUTT) == DVZ_OK);
+    AT(dvz_panel_add_visual(panel, visual, NULL) == DVZ_OK);
+
+    DvzApp* app = _app_test_create(suite, scene);
+    if (app == NULL)
+    {
+        dvz_scene_destroy(scene);
+        return -1;
+    }
+    DvzView* win = dvz_view_offscreen(app, figure, 96, 96);
+    AT(win != NULL);
+    DvzCanvas* canvas = dvz_view_canvas(win);
+    ANN(canvas);
+    dvz_app_run(app, 1);
+
+    AT(dvz_canvas_capture_rgba(canvas, &out->width, &out->height, &out->rgba) == DVZ_OK);
+    ANN(out->rgba);
+    AT(out->width == 96);
+    AT(out->height == 96);
+
+    dvz_app_destroy(app);
+    dvz_scene_destroy(scene);
+    return 0;
+}
+
+
+
+/**
+ * Ensure a path crossing behind the camera does not mirror across the viewport.
+ *
+ * @param suite the test suite
+ * @param item the test item
+ * @return 0 on success
+ */
+int test_app_offscreen_path_clips_behind_camera(TstContext* suite, const TstCase* item)
+{
+    ANN(suite);
+    (void)item;
+
+    TST_SCENE_APP_REQUIRE_VKLITE(suite);
+
+    DvzCameraDesc camera = dvz_camera_desc();
+    camera.projection.fov_y = GLM_PI_4f;
+    camera.projection.near_clip = 0.1f;
+    camera.projection.far_clip = 100.0f;
+    vec3 positions[2] = {{0.45f, 0.0f, 0.0f}, {0.45f, 0.0f, 3.5f}};
+    AppRgbaCapture capture = {0};
+    if (_app_capture_two_point_path(suite, positions, 12.0f, &camera, &capture) != 0)
+    {
+        log_warn("behind-camera path clipping test skipped: GPU context creation failed");
+        tst_skip(suite, "GPU context creation failed");
+        return 0;
+    }
+
+    uint32_t visible_count = 0;
+    uint32_t mirrored_count = 0;
+    for (uint32_t y = 0; y < capture.height; y++)
+    {
+        for (uint32_t x = 0; x < capture.width; x++)
+        {
+            const uint8_t* px = _pixel_at(capture.rgba, capture.width, capture.height, x, y);
+            if (px[0] <= 100 || px[0] <= px[1] + 45 || px[0] <= px[2] + 45)
+                continue;
+            if (x >= capture.width / 2u)
+                visible_count++;
+            else if (x < capture.width / 3u)
+                mirrored_count++;
+        }
+    }
+    AT(visible_count > 0);
+    AT(mirrored_count == 0);
+
+    dvz_free(capture.rgba);
+    return 0;
+}
+
+
+
+/**
+ * Ensure a thick path remains visible when its centerline is just outside the viewport.
+ *
+ * @param suite the test suite
+ * @param item the test item
+ * @return 0 on success
+ */
+int test_app_offscreen_path_preserves_lateral_stroke_overlap(
+    TstContext* suite, const TstCase* item)
+{
+    ANN(suite);
+    (void)item;
+
+    TST_SCENE_APP_REQUIRE_VKLITE(suite);
+
+    vec3 positions[2] = {{1.08f, -0.60f, 0.0f}, {1.08f, +0.60f, 0.0f}};
+    AppRgbaCapture capture = {0};
+    if (_app_capture_two_point_path(suite, positions, 16.0f, NULL, &capture) != 0)
+    {
+        log_warn("lateral path stroke overlap test skipped: GPU context creation failed");
+        tst_skip(suite, "GPU context creation failed");
+        return 0;
+    }
+
+    uint32_t edge_count = 0;
+    for (uint32_t y = 0; y < capture.height; y++)
+    {
+        for (uint32_t x = capture.width - 8u; x < capture.width; x++)
+        {
+            const uint8_t* px = _pixel_at(capture.rgba, capture.width, capture.height, x, y);
+            if (px[0] > 100 && px[0] > px[1] + 45 && px[0] > px[2] + 45)
+                edge_count++;
+        }
+    }
+    AT(edge_count > 0);
+
+    dvz_free(capture.rgba);
+    return 0;
+}
+
+
+
+/**
  * Ensure a sharp stroked path join contributes pixels at the join center.
  *
  * @param suite the test suite
@@ -10317,6 +10473,8 @@ int test_scene_app(TstSuite* suite)
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_point_depth_cue_darkens_far);
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_point_default_edge_has_fractional_pixels);
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_has_nonblank_pixels);
+    TST_SCENE_APP_SHARED_CASE(test_app_offscreen_path_clips_behind_camera);
+    TST_SCENE_APP_SHARED_CASE(test_app_offscreen_path_preserves_lateral_stroke_overlap);
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_path_join_has_no_center_gap);
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_path_join_modes_are_ordered);
     TST_SCENE_APP_SHARED_CASE(test_app_offscreen_path_closed_star_seam_has_pixels);

--- a/src/scene/tests/test_scene.h
+++ b/src/scene/tests/test_scene.h
@@ -1378,6 +1378,11 @@ int test_scene_text_block_image_lowering(TstContext* suite, const TstCase* item)
 #if defined(DVZ_HAS_APP) && DVZ_HAS_APP
 int test_app_offscreen_has_nonblank_pixels(TstContext* suite, const TstCase* item);
 
+int test_app_offscreen_path_clips_behind_camera(TstContext* suite, const TstCase* item);
+
+int test_app_offscreen_path_preserves_lateral_stroke_overlap(
+    TstContext* suite, const TstCase* item);
+
 int test_app_offscreen_path_join_has_no_center_gap(TstContext* suite, const TstCase* item);
 
 int test_app_offscreen_path_join_modes_are_ordered(TstContext* suite, const TstCase* item);


### PR DESCRIPTION
Fixes #150.

  ## Summary

  `path.vert` and `path_query_u32.vert` projected control points before clipping. Because `deviceClipToTopLeftPixel()` divides by `abs(w)`, behind-camera vertices were mirrored through the viewport centre and could create stray wedges. This change clips stroke
  centerlines before projection, keeps rendering and picking aligned, and preserves visible overlap from screen-space strokes just outside lateral frustum planes.

  ## Changes

  - Moves the shared clip-plane and near-plane helpers into `stroke.glsl` and reuses them from path and segment render/query shaders.
  - Clips each path core segment before projection, discarding fully outside segments without projecting negative `w`.
  - Clips join neighbours only against the near plane so lateral clipping does not alter join direction.
  - Suppresses joins and caps at generated clip boundaries.
  - Expands lateral clip planes by the analytic screen-space stroke and cap reach, preserving footprints whose centerlines are just outside the viewport.
  - Leaves near and depth clipping unchanged.
  - Applies the same footprint-aware policy to rendering and picking variants.

  ## Automated regressions

  - `test_app_offscreen_path_clips_behind_camera` renders a perspective path crossing behind the camera and asserts that the visible portion remains without mirrored pixels across the viewport.
  - `test_app_offscreen_path_preserves_lateral_stroke_overlap` renders a 16 px path whose centerline is 3.84 px beyond a 96 px viewport edge and asserts that its overlapping footprint contributes edge pixels.

  The lateral-overlap regression failed before the footprint-aware change with `edge_count == 0` and passes afterward.

  ## Evidence

  The rendered reproduction from #150 changed from 7,245 stray pixels before clipping to zero after clipping, with the authored path matching the CPU-clipped reference.

  ## Verification

  - `just build` — passed
  - `just shader-abi-check` — passed
  - Path-focused tests — 13/13 passed
  - Segment-focused tests — 5/5 passed
  - Scene suite — 754/754 passed