### PR TITLE
fix(scene): remove obsolete common uniform cache limit

### DIFF
--- a/src/scene/frame_plan/emit.h
+++ b/src/scene/frame_plan/emit.h
@@ -47,7 +47,6 @@
 #define DRP2_MAX_FIXTURE_RESOURCES 64
 #define DRP2_RUNTIME_TRANSIENT_ID_BASE 10000
 #define DRP2_EMITTER_OBJECT_ID_BASE 5000
-#define DVZ_SCENE_COMMON_CACHE_CAPACITY (2 * DVZ_SCENE_MAX_PANELS)
 #define DVZ_SCENE_VOLUME_CACHE_CAPACITY DVZ_SCENE_MAX_VISUALS
 #define DVZ_SCENE_LABELS_CACHE_CAPACITY DVZ_SCENE_MAX_VISUALS
 #define DVZ_SCENE_LABELS_HIDDEN_VEC4_COUNT ((DVZ_LABELS_MAX_HIDDEN + 3u) / 4u)
@@ -149,13 +148,6 @@ struct DvzFramePlanEmitter
     uint32_t max_color_sample_count;
     uint32_t max_depth_sample_count;
 
-    /* Common cache: APPLY and FIXED slots are panel-specific once viewport is part of set 0. */
-    char mvp_panel_ids[DVZ_SCENE_COMMON_CACHE_CAPACITY][DVZ_SCENE_LABEL_SIZE];
-    DvzMVP mvp_cache[DVZ_SCENE_COMMON_CACHE_CAPACITY];
-    uint32_t mvp_panel_count;
-    char viewport_panel_ids[DVZ_SCENE_COMMON_CACHE_CAPACITY][DVZ_SCENE_LABEL_SIZE];
-    DvzSceneViewportUniform viewport_cache[DVZ_SCENE_COMMON_CACHE_CAPACITY];
-    uint32_t viewport_panel_count;
     char volume_ids[DVZ_SCENE_VOLUME_CACHE_CAPACITY][DVZ_SCENE_LABEL_SIZE];
     DvzSceneVolumeUniform volume_cache[DVZ_SCENE_VOLUME_CACHE_CAPACITY];
     uint32_t volume_count;
@@ -183,11 +175,6 @@ void _emitter_state_commit(
 void _emitter_state_discard(DvzFramePlanEmitter* candidate);
 
 uint64_t _emitter_next_transient_id(DvzFramePlanEmitter* emitter);
-
-DvzMVP* _emitter_mvp_slot(DvzFramePlanEmitter* emitter, const char* key);
-
-DvzSceneViewportUniform*
-_emitter_viewport_slot(DvzFramePlanEmitter* emitter, const char* key);
 
 DvzSceneVolumeUniform*
 _emitter_volume_slot(DvzFramePlanEmitter* emitter, const char* key);

--- a/src/scene/runtime/common_bindings.c
+++ b/src/scene/runtime/common_bindings.c
@@ -204,7 +204,6 @@ static bool _resolve_common_set(
     *out_bg_id = 0;
 
     char mvp_buf_key[256], viewport_buf_key[256], bg_key[256];
-    char mvp_slot_key[256], viewport_slot_key[256];
     const char* viewport_tag =
         viewport_rect == DVZ_FRAME_PLAN_VIEWPORT_PLOT     ? "plot" :
         viewport_rect == DVZ_FRAME_PLAN_VIEWPORT_TARGET   ? "target" :
@@ -218,12 +217,6 @@ static bool _resolve_common_set(
     dvz_snprintf(
         bg_key, sizeof(bg_key), "_common_bg_%s_%s_%s", render->u.render.panel_id, mode_tag,
         viewport_tag);
-    dvz_snprintf(
-        mvp_slot_key, sizeof(mvp_slot_key), "%s_%s_%s", render->u.render.panel_id, mode_tag,
-        viewport_tag);
-    dvz_snprintf(
-        viewport_slot_key, sizeof(viewport_slot_key), "%s_%s_%s", render->u.render.panel_id,
-        mode_tag, viewport_tag);
 
     bool is_new = false;
     uint32_t usage = DVZ_DRP2_BUFFER_USAGE_UNIFORM | DVZ_DRP2_BUFFER_USAGE_MAP_WRITE |
@@ -274,11 +267,10 @@ static bool _resolve_common_set(
             return false;
     }
 
+    /* The command stream copies write-buffer payloads on record, so these uniforms are built
+       fresh per emission as locals rather than kept in per-panel emitter scratch. */
     DvzMVP local_identity = {0};
     const DvzMVP* mvp_src = &render->u.render.apply_mvp;
-    DvzMVP* mvp_slot = _emitter_mvp_slot(emitter, mvp_slot_key);
-    if (mvp_slot == NULL)
-        return false;
     if (override_mvp != NULL)
         mvp_src = override_mvp;
     else if (fixed || !render->u.render.has_mvp)
@@ -286,23 +278,18 @@ static bool _resolve_common_set(
         _identity_mvp(&local_identity);
         mvp_src = &local_identity;
     }
-    _mvp_uniform_copy(mvp_slot, mvp_src);
-    mvp_slot->flags |= mvp_flags;
-    mvp_src = mvp_slot;
+    DvzMVP local_mvp = {0};
+    _mvp_uniform_copy(&local_mvp, mvp_src);
+    local_mvp.flags |= mvp_flags;
 
     DvzSceneViewportUniform local_viewport = {0};
     _viewport_uniform_from_render(render, viewport_rect, &local_viewport);
-    DvzSceneViewportUniform* viewport_slot =
-        _emitter_viewport_slot(emitter, viewport_slot_key);
-    if (viewport_slot == NULL)
-        return false;
-    *viewport_slot = local_viewport;
 
     if (!dvz_drp2_stream_write_buffer_bytes(
-            stream, mvp_buf_id, 0, sizeof(DvzMVP), mvp_src))
+            stream, mvp_buf_id, 0, sizeof(DvzMVP), &local_mvp))
         return false;
     if (!dvz_drp2_stream_write_buffer_bytes(
-            stream, viewport_buf_id, 0, sizeof(DvzSceneViewportUniform), viewport_slot))
+            stream, viewport_buf_id, 0, sizeof(DvzSceneViewportUniform), &local_viewport))
         return false;
 
     *out_bg_id = bg_id;

--- a/src/scene/runtime/state.c
+++ b/src/scene/runtime/state.c
@@ -225,56 +225,6 @@ uint64_t _emitter_next_transient_id(DvzFramePlanEmitter* emitter)
 
 
 /**
- * Return the MVP cache slot for a panel key, creating it when capacity allows.
- *
- * @param emitter the persistent emitter
- * @param key the MVP cache key
- * @return the cached MVP slot, or NULL when the cache is full
- */
-DvzMVP* _emitter_mvp_slot(DvzFramePlanEmitter* emitter, const char* key)
-{
-    ANN(emitter);
-    ANN(key);
-    for (uint32_t i = 0; i < emitter->mvp_panel_count; i++)
-    {
-        if (strncmp(emitter->mvp_panel_ids[i], key, DVZ_SCENE_LABEL_SIZE) == 0)
-            return &emitter->mvp_cache[i];
-    }
-    if (emitter->mvp_panel_count >= DVZ_SCENE_COMMON_CACHE_CAPACITY)
-        return NULL;
-    uint32_t slot = emitter->mvp_panel_count++;
-    strncpy(emitter->mvp_panel_ids[slot], key, DVZ_SCENE_LABEL_SIZE - 1);
-    return &emitter->mvp_cache[slot];
-}
-
-
-
-/**
- * Return the viewport cache slot for a panel key, creating it when capacity allows.
- *
- * @param emitter the persistent emitter
- * @param key the viewport cache key
- * @return the cached viewport slot, or NULL when the cache is full
- */
-DvzSceneViewportUniform*
-_emitter_viewport_slot(DvzFramePlanEmitter* emitter, const char* key)
-{
-    ANN(emitter);
-    ANN(key);
-    for (uint32_t i = 0; i < emitter->viewport_panel_count; i++)
-    {
-        if (strncmp(emitter->viewport_panel_ids[i], key, DVZ_SCENE_LABEL_SIZE) == 0)
-            return &emitter->viewport_cache[i];
-    }
-    if (emitter->viewport_panel_count >= DVZ_SCENE_COMMON_CACHE_CAPACITY)
-        return NULL;
-    uint32_t slot = emitter->viewport_panel_count++;
-    strncpy(emitter->viewport_panel_ids[slot], key, DVZ_SCENE_LABEL_SIZE - 1);
-    return &emitter->viewport_cache[slot];
-}
-
-
-/**
  * Return the volume uniform cache slot for a visual key, creating it when capacity allows.
  *
  * @param emitter the persistent emitter

--- a/src/scene/tests/frame_plan_emit.c
+++ b/src/scene/tests/frame_plan_emit.c
@@ -1790,8 +1790,6 @@ static int test_frame_plan_emitter_failure_rolls_back_state(
     AT(emitter->next_transient_id == DRP2_RUNTIME_TRANSIENT_ID_BASE);
     AT(emitter->max_color_sample_count == 16);
     AT(emitter->max_depth_sample_count == 16);
-    AT(emitter->mvp_panel_count == 0);
-    AT(emitter->viewport_panel_count == 0);
     AT(emitter->volume_count == 0);
     AT(emitter->labels_count == 0);
 
@@ -1825,6 +1823,94 @@ static int test_frame_plan_emitter_failure_rolls_back_state(
     _test_scene_stream_destroy(retry);
     dvz_frame_plan_destroy(plan);
     dvz_frame_plan_emitter_destroy(fresh);
+    dvz_frame_plan_emitter_destroy(emitter);
+    return 0;
+}
+
+
+/**
+ * Ensure common bindings scale past the retired 128-slot panel/visual cache.
+ *
+ * @param suite the active test suite
+ * @param item the active test item
+ * @return 0 on success
+ */
+static int test_frame_plan_emitter_common_bindings_beyond_legacy_cache(
+    TstContext* suite, const TstCase* item)
+{
+    ANN(suite);
+    (void)item;
+
+    const uint32_t panel_count = 2;
+    const uint32_t visuals_per_panel = 65;
+    const uint32_t expected_common_sets = panel_count * visuals_per_panel;
+
+    DvzFramePlanEmitter* emitter = dvz_frame_plan_emitter();
+    ANN(emitter);
+
+    DvzFramePlan* plan = dvz_frame_plan("figure.common.bindings.scale", 23);
+    ANN(plan);
+    AT(dvz_frame_plan_upload(plan, "point-position", 0, 3 * 3 * sizeof(float), "position"));
+    AT(dvz_frame_plan_upload(plan, "point-color", 0, 3 * sizeof(DvzColor), "color"));
+    AT(dvz_frame_plan_upload(plan, "point-size", 0, 3 * sizeof(float), "size"));
+
+    for (uint32_t p = 0; p < panel_count; p++)
+    {
+        char panel_id[DVZ_SCENE_LABEL_SIZE], target_id[DVZ_SCENE_LABEL_SIZE];
+        dvz_snprintf(panel_id, sizeof(panel_id), "panel.%u", p);
+        dvz_snprintf(target_id, sizeof(target_id), "target.panel.%u.color", p);
+        AT(dvz_frame_plan_render(plan, panel_id, target_id, false));
+        for (uint32_t v = 0; v < visuals_per_panel; v++)
+        {
+            char visual_id[DVZ_SCENE_LABEL_SIZE];
+            dvz_snprintf(visual_id, sizeof(visual_id), "visual.point.%u.%u", p, v);
+            AT(dvz_frame_plan_render_visual(plan, visual_id));
+
+            DvzFramePlanVisualMeta metadata = {0};
+            metadata.visual_type = DVZ_VISUAL_TYPE_POINT;
+            metadata.renderable_kind = DVZ_RENDERABLE_POINT_LIKE;
+            metadata.vertex_count = 3;
+            metadata.alpha_mode = DVZ_ALPHA_OPAQUE;
+            dvz_strlcpy(metadata.position_id, "point-position", sizeof(metadata.position_id));
+            dvz_strlcpy(metadata.color_id, "point-color", sizeof(metadata.color_id));
+            dvz_strlcpy(metadata.size_id, "point-size", sizeof(metadata.size_id));
+            AT(dvz_frame_plan_render_visual_metadata(plan, &metadata));
+        }
+    }
+
+    DvzCapabilitySnapshot caps = dvz_capability_snapshot();
+    DvzFramePlanEmitConfig cfg = dvz_frame_plan_emit_config();
+    cfg.shader_format = DVZ_SCENE_SHADER_FORMAT_GLSL;
+
+    /* Each panel/visual pair needs its own common set; the retired cache stopped at 128. */
+    DvzDiagnosticReport report = {0};
+    dvz_diagnostic_report_init(&report);
+    DvzDrp2CommandStream* first =
+        dvz_frame_plan_emitter_emit_drp2(emitter, plan, &caps, &report, &cfg);
+    ANN(first);
+    AT(dvz_diagnostic_report_count(&report) == 0);
+    AT(dvz_drp2_validate_stream(first).ok);
+
+    uint32_t bind_groups = 0;
+    for (uint32_t i = 0; i < dvz_drp2_stream_count(first); i++)
+    {
+        const DvzDrp2Command* command = dvz_drp2_stream_get(first, i);
+        ANN(command);
+        if (command->type == DVZ_DRP2_COMMAND_CREATE_BIND_GROUP)
+            bind_groups++;
+    }
+    AT(bind_groups >= expected_common_sets);
+
+    /* The persistent emitter reuses committed state, so the retry is an update-only stream. */
+    dvz_diagnostic_report_init(&report);
+    DvzDrp2CommandStream* second =
+        dvz_frame_plan_emitter_emit_drp2(emitter, plan, &caps, &report, &cfg);
+    ANN(second);
+    AT(dvz_diagnostic_report_count(&report) == 0);
+
+    _test_scene_stream_destroy(second);
+    _test_scene_stream_destroy(first);
+    dvz_frame_plan_destroy(plan);
     dvz_frame_plan_emitter_destroy(emitter);
     return 0;
 }
@@ -3709,6 +3795,7 @@ int test_scene_frame_plan_emit(TstSuite* suite)
     TST_CASE(test_frame_plan_emit_drp2_split_packets);
     TST_CASE(test_frame_plan_emitter_rejects_untyped_visual_metadata);
     TST_CASE(test_frame_plan_emitter_failure_rolls_back_state);
+    TST_CASE(test_frame_plan_emitter_common_bindings_beyond_legacy_cache);
     TST_CASE(test_frame_plan_emit_drp2_rejects_unsupported_shader_format);
     TST_CASE(test_frame_plan_emit_drp2_rejects_small_caps);
 #if defined(DVZ_DRP2_HAS_VKLITE) && DVZ_DRP2_HAS_VKLITE


### PR DESCRIPTION
Fixes #152 

## Problem

`DvzFramePlanEmitter` carried two fixed-size CPU arrays, `mvp_cache` and `viewport_cache`, each `DVZ_SCENE_COMMON_CACHE_CAPACITY` (128) entries. `_resolve_common_set()` used them as scratch before recording a write-buffer command. When either filled, `_emitter_mvp_slot()` / `_emitter_viewport_slot()` returned `NULL` and the emission failed with `failed to prepare scene render batch`. The key is per panel × visual × controller mode × work provider × viewport rect, so figures exhaust it well below `DVZ_SCENE_MAX_PANELS`.

## Change

The cache is deleted rather than enlarged, because it no longer has a job. Removed: `DVZ_SCENE_COMMON_CACHE_CAPACITY`, the four arrays and two counters in `DvzFramePlanEmitter`, `_emitter_mvp_slot()`, `_emitter_viewport_slot()`, and the two now-unused slot-key `dvz_snprintf` calls. `_resolve_common_set()` now builds `DvzMVP` and `DvzSceneViewportUniform` as locals and passes them straight to `dvz_drp2_stream_write_buffer_bytes()`.

## Why this is safe

The arrays existed only to keep the payload alive past the end of `_resolve_common_set()`. `e1b99d758` (*Fix DRP2 write-buffer payload lifetime*) made `dvz_drp2_stream_write_buffer_bytes()` `dvz_malloc` a copy of every raw payload and own it, six days after `9b2a34049` introduced the cache. Since then the slots have been write-only: `_mvp_uniform_copy()` zeroes the destination and reassigns every field including `flags`, so `mvp_slot->flags |= mvp_flags` accumulated nothing across frames, and the viewport slot was overwritten wholesale from a local. No slot value was ever read back on a later emission, so replacing the slots with locals is behavior-preserving byte for byte.

## Unchanged

Resource keys, provider and visual identity, bind-group ids, and `_obj_id()`-keyed GPU buffer reuse, so persistent GPU object identity across frames is untouched. Public headers, exported API, ABI, shaders, and DRP2 semantics, so no `just ctypes` refresh is needed. The volume and labels caches, which are sized against `DVZ_SCENE_MAX_VISUALS`, are genuinely per-visual, and are not implicated. No `spec/` or release-status document changes.

## Side benefit

The two arrays were 59 KiB of the emitter struct, and `_emitter_state_clone()` memsets and then copies the whole `DvzFramePlanEmitter` per emission. This removes two passes over 59 KiB per frame from the transactional clone.

## Test

`test_frame_plan_emitter_common_bindings_beyond_legacy_cache` builds two render nodes of 65 typed `DVZ_VISUAL_TYPE_POINT` visuals each, 130 distinct common sets, and asserts that the first emission succeeds with no diagnostics, validates as DRP2, and records at least 130 `CreateBindGroup` commands, and that a second emission through the same persistent emitter also succeeds, proving committed transactional state is still reused.

On `main` it fails at the first emission, which returns `NULL` when the 129th slot is requested. Under GDB, `_emitter_mvp_slot()` refuses at `mvp_panel_count == 128` for key `panel.1_apply_provider_7_visual.point.1.63_panel`.

`test_frame_plan_emitter_failure_rolls_back_state` loses its two assertions on the deleted counters; its remaining assertions are unchanged.

## Validation

- `just build Release` from a wiped tree, 1277/1277 targets, and `just build` (Debug, the repo default), both clean.
- `just test scene` under both configurations, 757/757 each.
- `just test common_bindings_beyond_legacy_cache`, passes with the patch and fails without it.
- `just spec-check`, all guards pass: DRP2 fixtures 137/137 and 44/44, WebGPU runner smoke, shader ABI, scene visual boundary, scene query source, scene architecture source.
- `git diff --check`, clean.